### PR TITLE
Club enhancements in dashboard and club list

### DIFF
--- a/lib/commons/app_bar_with_image.dart
+++ b/lib/commons/app_bar_with_image.dart
@@ -46,9 +46,10 @@ class AppBarWithImage extends StatelessWidget {
                       : SizedBox(),
                 ),
                 flexibleSpace: FlexibleSpaceBar(
+
                   centerTitle: true,
                   title: PreferredSize(
-                    preferredSize: Size.fromHeight(100),
+                    preferredSize: Size.fromHeight(10),
                     child: Padding(
                       padding: const EdgeInsets.only(bottom: 4.0),
                       child: Row(
@@ -73,11 +74,14 @@ class AppBarWithImage extends StatelessWidget {
                                     .title),
                           ),
                           if (favorite != null)
-                            FavoriteIcon(
-                              favorite.id,
-                              favorite.type,
-                              favorite.value,
-                              padding: EdgeInsets.zero,
+                            ConstrainedBox(
+                              constraints: BoxConstraints(maxHeight: 40),
+                              child: FavoriteIcon(
+                                favorite.id,
+                                favorite.type,
+                                favorite.value,
+                                padding: EdgeInsets.zero,
+                              ),
                             ),
                         ],
                       ),

--- a/lib/commons/favorite/favorite_icon.dart
+++ b/lib/commons/favorite/favorite_icon.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:like_button/like_button.dart';
 import 'package:v34/commons/favorite/favorite.dart';
 import 'package:v34/repositories/repository.dart';
 
@@ -22,40 +23,47 @@ class FavoriteIcon extends StatefulWidget {
   _FavoriteIconState createState() => _FavoriteIconState();
 }
 
-class _FavoriteIconState extends State<FavoriteIcon>
-    with SingleTickerProviderStateMixin {
+class _FavoriteIconState extends State<FavoriteIcon> with SingleTickerProviderStateMixin {
   Repository _repository;
-  bool _favorite;
 
   @override
   void initState() {
     super.initState();
     _repository = RepositoryProvider.of<Repository>(context);
-    _favorite = widget.favorite;
   }
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: () => _performToggleFavorite(),
       child: Padding(
         padding: widget.padding,
-        child: Icon(
-          _favorite ? Icons.star : Icons.star_border,
-          size: 26,
-          color: _favorite
-              ? Colors.yellow
-              : Theme.of(context).textTheme.body2.color,
+        child: LikeButton(
+          onTap: (fav) => _performToggleFavorite(fav),
+          size: 35,
+          circleColor: CircleColor(start: Colors.yellowAccent, end: Colors.redAccent),
+          bubblesColor: BubblesColor(
+            dotPrimaryColor: Colors.redAccent,
+            dotSecondaryColor: Colors.yellowAccent,
+          ),
+          isLiked: widget.favorite,
+          likeBuilder: (bool isLiked) {
+            return Icon(
+              isLiked ? Icons.star : Icons.star_border,
+              color: isLiked ? Colors.yellow : Theme
+                  .of(context)
+                  .textTheme
+                  .body2
+                  .color,
+              size: 26,
+            );
+          },
         ),
       ),
     );
   }
 
-  void _performToggleFavorite() {
-    setState(() {
-      _favorite = !_favorite;
-      _repository.updateFavorite(
-          widget.favoriteId, widget.favoriteType, _favorite);
-    });
+  Future<bool> _performToggleFavorite(bool favorite) async {
+    await _repository.updateFavorite(widget.favoriteId, widget.favoriteType, !favorite);
+    return !favorite;
   }
 }

--- a/lib/commons/feature_tour.dart
+++ b/lib/commons/feature_tour.dart
@@ -1,0 +1,42 @@
+import 'package:feature_discovery/feature_discovery.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class FeatureTour extends StatelessWidget {
+  final String featureId;
+  final Widget target;
+  final String title;
+  final List<String> paragraphs;
+  final Widget child;
+
+  FeatureTour({this.featureId, Widget target, this.title, this.paragraphs, @required this.child}): this.target = target ?? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DescribedFeatureOverlay(
+      contentLocation: ContentLocation.above,
+      featureId: featureId,
+      tapTarget: target,
+      title: Text(title),
+      description: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          ...paragraphs.expand(
+            (paragrah) => [
+              Text(paragrah),
+              Container(
+                height: 10,
+              ),
+            ],
+          ),
+        ],
+      ),
+      backgroundColor: Theme.of(context).cardTheme.color,
+      targetColor: Theme.of(context).textTheme.body1.color,
+      textColor: Colors.white,
+      overflowMode: OverflowMode.extendBackground,
+      child: child,
+      onDismiss: () async => false,
+    );
+  }
+}

--- a/lib/commons/paragraph.dart
+++ b/lib/commons/paragraph.dart
@@ -13,7 +13,7 @@ class Paragraph extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(left: 18.0, right: 8.0, top: 34.0, bottom: 18.0),
+      padding: const EdgeInsets.only(left: 18.0, right: 8.0, top: 44.0, bottom: 28.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/lib/commons/router.dart
+++ b/lib/commons/router.dart
@@ -1,0 +1,25 @@
+
+
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class Router {
+
+
+  static Future<T> push<T extends Object>({BuildContext context, WidgetBuilder builder}) {
+    return Navigator.push(
+        context,
+        PageRoute(builder: builder)
+    );
+  }
+
+}
+
+class PageRoute<T> extends MaterialPageRoute<T> {
+  PageRoute({WidgetBuilder builder, RouteSettings settings}): super(builder: builder, settings: settings);
+
+  @override
+  Duration get transitionDuration => Duration(milliseconds: 600);
+
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,18 @@
 import 'package:bloc/bloc.dart';
+import 'package:feature_discovery/feature_discovery.dart';
 import 'package:fluid_bottom_nav_bar/fluid_bottom_nav_bar.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:v34/commons/blocs/logging_bloc.dart';
 import 'package:v34/commons/env.dart';
+import 'package:v34/commons/feature_tour.dart';
+import 'package:v34/pages/club/club_page.dart';
 import 'package:v34/pages/competition/competition_page.dart';
 import 'package:v34/pages/dashboard/dashoard_page.dart';
-import 'package:v34/pages/find/find_page.dart';
 import 'package:v34/repositories/providers/agenda_provider.dart';
 import 'package:v34/repositories/providers/club_provider.dart';
 import 'package:v34/repositories/providers/favorite_provider.dart';
@@ -39,10 +44,12 @@ class _V34State extends State<V34> {
         teamProvider: TeamProvider(),
         agendaProvider: AgendaProvider(),
       ),
-      child: MaterialApp(
-        title: 'Volley34',
-        theme: AppTheme.theme(),
-        home: _MainPage(),
+      child: FeatureDiscovery(
+        child: MaterialApp(
+          title: 'Volley34',
+          theme: AppTheme.theme(),
+          home: _MainPage(),
+        ),
       ),
     );
   }
@@ -55,12 +62,28 @@ class _MainPage extends StatefulWidget {
 
 class __MainPageState extends State<_MainPage> {
   Widget _child;
+  Repository _repository;
 
   @override
   void initState() {
     super.initState();
     _child = DashboardPage();
     initializeDateFormatting();
+    SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
+      _repository = RepositoryProvider.of<Repository>(context);
+      _repository.loadFavoriteClubs().then((clubs) {
+        if (clubs.isEmpty) {
+          //FeatureDiscovery.clearPreferences(context, ["dashboard_feature_id", "competition_feature_id", "clubs_feature_id"]).then((_) {
+            Future.delayed(Duration(seconds: 1)).then((_) {
+              FeatureDiscovery.discoverFeatures(
+                context,
+                const <String>{"dashboard_feature_id", "competition_feature_id", "clubs_feature_id"},
+              );
+            });
+          //});
+        }
+      });
+    });
   }
 
   @override
@@ -71,17 +94,51 @@ class __MainPageState extends State<_MainPage> {
       body: _child,
       bottomNavigationBar: FluidNavBar(
         icons: [
-          FluidNavBarIcon(iconPath: "assets/dashboard.svg"),
-          FluidNavBarIcon(iconPath: "assets/competition-filled.svg"),
-          FluidNavBarIcon(iconPath: "assets/map-filled.svg"),
+          FluidNavBarIcon(iconPath: "assets/dashboard.svg", extras: {
+            "featureId": "dashboard_feature_id",
+            "title": "Tableau de bord",
+            "paragraphs": [
+              "L'ensemble de vos clubs et équipes favorites toujours à portée.",
+              "Retrouvez votre agenda, des statistiques et l'ensemble des informations utiles au jour le jour."
+            ],
+          }),
+          FluidNavBarIcon(iconPath: "assets/competition-filled.svg", extras: {
+            "featureId": "competition_feature_id",
+            "title": "Compétitions",
+            "paragraphs": [
+              "Championnats, Challenges et Coupe de printemps.",
+              "L'ensemble des résultats, classements par catégorie, poule et type de compétition."
+            ],
+          }),
+          FluidNavBarIcon(iconPath: "assets/map-filled.svg", extras: {
+            "featureId": "clubs_feature_id",
+            "title": "Liste des clubs",
+            "paragraphs": [
+              "Accédez à l'ensemble des clubs inscrits aux compétitions.",
+              "Sélectionnez un ou plusieurs favoris, ainsi accédez rapidement depuis le tableau de bord à des informations importantes sur vos favoris."
+            ],
+          }),
         ],
         style: FluidNavBarStyle(
           barBackgroundColor: Theme.of(context).bottomAppBarColor,
           iconSelectedForegroundColor: Color(0xFF313852),
-          iconUnselectedForegroundColor:
-              Theme.of(context).tabBarTheme.unselectedLabelColor,
+          iconUnselectedForegroundColor: Theme.of(context).tabBarTheme.unselectedLabelColor,
         ),
+        scaleFactor: 1.4,
         onChange: _handleNavigationChange,
+        itemBuilder: (icon, item) {
+          return FeatureTour(
+            child: item,
+            featureId: icon.extras["featureId"],
+            title: icon.extras["title"],
+            paragraphs: icon.extras["paragraphs"] ?? [],
+            target: SvgPicture.asset(
+              icon.iconPath,
+              height: 30,
+              color: Theme.of(context).tabBarTheme.unselectedLabelColor,
+            ),
+          );
+        },
       ),
     );
   }
@@ -96,7 +153,7 @@ class __MainPageState extends State<_MainPage> {
           _child = CompetitionPage();
           break;
         case 2:
-          _child = FindPage();
+          _child = ClubPage();
           break;
       }
       _child = AnimatedSwitcher(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,14 +73,12 @@ class __MainPageState extends State<_MainPage> {
       _repository = RepositoryProvider.of<Repository>(context);
       _repository.loadFavoriteClubs().then((clubs) {
         if (clubs.isEmpty) {
-          //FeatureDiscovery.clearPreferences(context, ["dashboard_feature_id", "competition_feature_id", "clubs_feature_id"]).then((_) {
-            Future.delayed(Duration(seconds: 1)).then((_) {
-              FeatureDiscovery.discoverFeatures(
-                context,
-                const <String>{"dashboard_feature_id", "competition_feature_id", "clubs_feature_id"},
-              );
-            });
-          //});
+          Future.delayed(Duration(seconds: 1)).then((_) {
+            FeatureDiscovery.discoverFeatures(
+              context,
+              const <String>{"dashboard_feature_id", "competition_feature_id", "clubs_feature_id"},
+            );
+          });
         }
       });
     });

--- a/lib/pages/club/club_card.dart
+++ b/lib/pages/club/club_card.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:v34/commons/favorite/favorite_icon.dart';
 import 'package:v34/commons/rounded_network_image.dart';
+import 'package:v34/commons/router.dart';
 import 'package:v34/models/club.dart';
 import 'package:v34/commons/favorite/favorite.dart';
 import 'package:v34/pages/club-details/club_detail_page.dart';
+import 'package:v34/repositories/repository.dart';
 
 class ClubCard extends StatefulWidget {
   final Club club;
@@ -17,6 +20,22 @@ class ClubCard extends StatefulWidget {
 }
 
 class _ClubCardState extends State<ClubCard> {
+  Repository _repository;
+  bool _favorite = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _repository = RepositoryProvider.of<Repository>(context);
+    _loadFavorite();
+  }
+
+  void _loadFavorite() {
+    _repository.isClubFavorite(widget.club.code).then((favorite) {
+      setState(() => _favorite = favorite);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Stack(
@@ -27,7 +46,7 @@ class _ClubCardState extends State<ClubCard> {
             padding: const EdgeInsets.only(left: 14.0),
             child: Card(
               child: InkWell(
-                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (context) => ClubDetailPage(widget.club))),
+                onTap: () => Router.push(context: context, builder: (_) => ClubDetailPage(widget.club)).then((_) => _loadFavorite()),
                 child: Padding(
                   padding: const EdgeInsets.only(top: 18.0, right: 8.0, bottom: 12.0, left: 48.0),
                   child: Column(
@@ -55,7 +74,7 @@ class _ClubCardState extends State<ClubCard> {
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: <Widget>[
-            FavoriteIcon(widget.club.code, FavoriteType.Club, widget.club.favorite),
+            FavoriteIcon(widget.club.code, FavoriteType.Club, _favorite),
           ],
         ),
       ],

--- a/lib/pages/club/club_page.dart
+++ b/lib/pages/club/club_page.dart
@@ -2,12 +2,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
+import 'package:v34/commons/paragraph.dart';
 import 'package:v34/models/club.dart';
 import 'package:v34/pages/find/club_card.dart';
-import 'package:v34/repositories/providers/agenda_provider.dart';
-import 'package:v34/repositories/providers/club_provider.dart';
-import 'package:v34/repositories/providers/favorite_provider.dart';
-import 'package:v34/repositories/providers/team_provider.dart';
 import 'package:v34/repositories/repository.dart';
 
 class ClubPage extends StatefulWidget {
@@ -25,15 +22,26 @@ class _ClubPageState extends State<ClubPage> with SingleTickerProviderStateMixin
   void initState() {
     super.initState();
     _repository = RepositoryProvider.of<Repository>(context);
-    _repository.loadClubs().then((clubs) {
-      setState(() {
-        _clubs = clubs;
-        _loading = false;
-      });
-    });
-    setState(() => _loading = true);
+    _loadClubs();
   }
 
+  @override
+  void didUpdateWidget(ClubPage oldWidget) async {
+    _loadClubs();
+    super.didUpdateWidget(oldWidget);
+  }
+
+  void _loadClubs() {
+    setState(() {
+      _loading = true;
+    });
+    _repository.loadAllClubs().then((clubs) {
+      setState(() {
+        _loading = false;
+        _clubs = clubs;
+      });
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -42,20 +50,22 @@ class _ClubPageState extends State<ClubPage> with SingleTickerProviderStateMixin
         : Stack(children: <Widget>[
             AnimationLimiter(
               child: ListView.builder(
-                itemCount: _clubs.length,
+                itemCount: _clubs.length + 1,
                 itemBuilder: (context, index) {
-                  return index < _clubs.length
-                      ? AnimationConfiguration.staggeredList(
-                          position: index,
-                          duration: const Duration(milliseconds: 375),
-                          child: SlideAnimation(
-                            horizontalOffset: 50.0,
-                            child: FadeInAnimation(
-                              child: ClubCard(_clubs[index], index),
-                            ),
-                          ),
-                        )
-                      : SizedBox(height: 56);
+                  return index == 0
+                      ? Paragraph(title: "Liste des clubs")
+                      : index < _clubs.length
+                          ? AnimationConfiguration.staggeredList(
+                              position: index,
+                              duration: const Duration(milliseconds: 375),
+                              child: SlideAnimation(
+                                horizontalOffset: 50.0,
+                                child: FadeInAnimation(
+                                  child: ClubCard(_clubs[index], index),
+                                ),
+                              ),
+                            )
+                          : SizedBox(height: 56);
                 },
               ),
             ),

--- a/lib/pages/club/club_page.dart
+++ b/lib/pages/club/club_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
 import 'package:v34/commons/paragraph.dart';
 import 'package:v34/models/club.dart';
-import 'package:v34/pages/find/club_card.dart';
+import 'package:v34/pages/club/club_card.dart';
 import 'package:v34/repositories/repository.dart';
 
 class ClubPage extends StatefulWidget {

--- a/lib/pages/dashboard/blocs/favorite_bloc.dart
+++ b/lib/pages/dashboard/blocs/favorite_bloc.dart
@@ -61,7 +61,7 @@ class FavoriteBloc extends Bloc<FavoriteEvent, FavoriteState> {
   Stream<FavoriteState> mapEventToState(FavoriteEvent event) async* {
     if (event is FavoriteLoadEvent) {
       yield FavoriteLoadingState([], []);
-      var favClubs = await repository.loadFavoriteClub();
+      var favClubs = await repository.loadFavoriteClubs();
       yield FavoriteLoadedState([], favClubs);
     }
   }

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -1,7 +1,11 @@
 import 'package:collection/collection.dart';
+import 'package:feature_discovery/feature_discovery.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+import 'package:v34/commons/feature_tour.dart';
+import 'package:v34/commons/router.dart';
+import 'package:v34/pages/club-details/club_detail_page.dart';
 import 'package:v34/pages/dashboard/blocs/agenda_bloc.dart';
 import 'package:v34/pages/dashboard/blocs/favorite_bloc.dart';
 import 'package:v34/commons/paragraph.dart';
@@ -23,13 +27,9 @@ class _DashboardPageState extends State<DashboardPage> {
   @override
   void initState() {
     super.initState();
-    _favoriteBloc =
-        FavoriteBloc(repository: RepositoryProvider.of<Repository>(context))
-          ..add(FavoriteLoadEvent());
-    _agendaBloc =
-        AgendaBloc(repository: RepositoryProvider.of<Repository>(context))
-          ..add(AgendaLoadWeek(week: 0));
-    _pageController = PageController(initialPage: 0, viewportFraction: 0.85);
+    _favoriteBloc = FavoriteBloc(repository: RepositoryProvider.of<Repository>(context))..add(FavoriteLoadEvent());
+    _agendaBloc = AgendaBloc(repository: RepositoryProvider.of<Repository>(context))..add(AgendaLoadWeek(week: 0));
+    _pageController = PageController(initialPage: 0);
   }
 
   @override
@@ -42,51 +42,69 @@ class _DashboardPageState extends State<DashboardPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.only(top: 55),
-      child: BlocBuilder<FavoriteBloc, FavoriteState>(
-          bloc: _favoriteBloc,
-          builder: (context, state) {
-            return (state is FavoriteLoadedState)
-                ? ListView.builder(
-                    shrinkWrap: true,
-                    itemCount: 6,
-                    itemBuilder: (context, index) {
-                      return _buildDashboardItem(
-                        index,
-                        state,
-                      );
-                    },
-                  )
-                : SizedBox();
-          }),
-    );
+    return BlocBuilder<FavoriteBloc, FavoriteState>(
+        bloc: _favoriteBloc,
+        builder: (context, state) {
+          return (state is FavoriteLoadedState)
+              ? ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: 6,
+                  itemBuilder: (context, index) {
+                    return _buildDashboardItem(
+                      index,
+                      state,
+                    );
+                  },
+                )
+              : SizedBox();
+        });
   }
 
   Widget _buildDashboardItem(int index, FavoriteState state) {
     switch (index) {
       case 0:
-        return Paragraph(
-            title: state.teamCodes.length > 1 ? "Vos équipes" : "Votre équipe");
+        return Paragraph(title: state.clubs.length > 1 ? "Vos clubs" : "Votre club");
       case 1:
-        return Container(height: 120);
-      case 2:
-        return Paragraph(
-            title: state.clubs.length > 1 ? "Vos clubs" : "Votre club");
-      case 3:
         return (state is FavoriteLoadedState)
-            ? Container(
-                height: 200,
-                child: PageView.builder(
-                  itemCount: state.clubs.length,
-                  controller: _pageController,
-                  itemBuilder: (context, index) =>
-                      FavoriteClubCard(state.clubs[index]),
-                ))
+            ? Column(
+                children: <Widget>[
+                  Container(
+                    height: 200,
+                    child: PageView.builder(
+                      itemCount: state.clubs.length,
+                      controller: _pageController,
+                      itemBuilder: (context, index) => Padding(
+                        padding: const EdgeInsets.only(left: 8.0, right: 16),
+                        child: FavoriteClubCard(
+                          state.clubs[index],
+                          () => Router.push(context: context, builder: (_) => ClubDetailPage(state.clubs[index])).then(
+                            (_) => _favoriteBloc.add(FavoriteLoadEvent()),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  if (state.clubs.length > 1)
+                    SmoothPageIndicator(
+                      controller: _pageController,
+                      count: state.clubs.length,
+                      effect: WormEffect(
+                        dotHeight: 8,
+                        dotWidth: 8,
+                        dotColor: Theme.of(context).cardTheme.color,
+                        activeDotColor: Theme.of(context).accentColor,
+                      ),
+                    )
+                ],
+              )
             : Container(
                 constraints: BoxConstraints(minHeight: 100),
                 child: Center(child: CircularProgressIndicator()),
               );
+      case 2:
+        return Paragraph(title: state.teamCodes.length > 1 ? "Vos équipes" : "Votre équipe");
+      case 3:
+        return Container(height: 120);
       case 4:
         return Paragraph(title: "Votre agenda");
       case 5:
@@ -97,20 +115,18 @@ class _DashboardPageState extends State<DashboardPage> {
                 padding: const EdgeInsets.only(top: 18, bottom: 28.0),
                 child: agendaState is AgendaLoaded
                     ? Timeline([
-                        ...groupBy(
-                                agendaState.events, (event) => DateTime(event.date.year, event.date.month, event.date.day))
-                            .entries
-                            .expand((entry) {
+                        ...groupBy(agendaState.events, (event) => DateTime(event.date.year, event.date.month, event.date.day)).entries.expand((entry) {
                           return [
                             TimelineItem(date: entry.key, events: [
-                            ...entry.value.map((e) {
-                              TimelineItemWidget timelineItemWidget = TimelineItemWidget.from(e);
-                              return TimelineEvent(
-                                child: timelineItemWidget,
-                                color: timelineItemWidget.color(),
-                              );
-                            })
-                          ])];
+                              ...entry.value.map((e) {
+                                TimelineItemWidget timelineItemWidget = TimelineItemWidget.from(e);
+                                return TimelineEvent(
+                                  child: timelineItemWidget,
+                                  color: timelineItemWidget.color(),
+                                );
+                              })
+                            ])
+                          ];
                         }),
                       ])
                     : Center(child: CircularProgressIndicator()),

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -1,9 +1,7 @@
 import 'package:collection/collection.dart';
-import 'package:feature_discovery/feature_discovery.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
-import 'package:v34/commons/feature_tour.dart';
 import 'package:v34/commons/router.dart';
 import 'package:v34/pages/club-details/club_detail_page.dart';
 import 'package:v34/pages/dashboard/blocs/agenda_bloc.dart';

--- a/lib/pages/dashboard/fav_club_card.dart
+++ b/lib/pages/dashboard/fav_club_card.dart
@@ -9,8 +9,8 @@ import 'package:v34/repositories/repository.dart';
 
 class FavoriteClubCard extends StatefulWidget {
   final Club club;
-
-  FavoriteClubCard(this.club);
+  final GestureTapCallback onTap;
+  FavoriteClubCard(this.club, this.onTap);
 
   @override
   _FavoriteClubCardState createState() => _FavoriteClubCardState();
@@ -72,7 +72,7 @@ class _FavoriteClubCardState extends State<FavoriteClubCard> {
           padding: const EdgeInsets.only(left: 14.0),
           child: Card(
             child: InkWell(
-              onTap: () => print("Tapped"),
+              onTap: widget.onTap,
               child: BlocListener(
                   listener: (context, state) {
                     if (state is ClubStatsLoadedState) {
@@ -108,7 +108,13 @@ class _FavoriteClubCardState extends State<FavoriteClubCard> {
           ),
         ),
       ),
-      Padding(padding: const EdgeInsets.only(left: 8.0, bottom: 140), child: RoundedNetworkImage(40, widget.club.logoUrl)),
+      Padding(
+        padding: const EdgeInsets.only(left: 8.0, bottom: 140),
+        child: Hero(
+          tag: "hero-logo-${widget.club.code}",
+          child: RoundedNetworkImage(40, widget.club.logoUrl),
+        ),
+      ),
     ]);
   }
 
@@ -127,7 +133,10 @@ class _FavoriteClubCardState extends State<FavoriteClubCard> {
               children: <Widget>[
                 Padding(
                   padding: const EdgeInsets.only(right: 8.0),
-                  child: Text("Matchs gagnés", style: Theme.of(context).textTheme.body1,),
+                  child: Text(
+                    "Matchs gagnés",
+                    style: Theme.of(context).textTheme.body1,
+                  ),
                 ),
                 Stack(alignment: Alignment.center, children: [
                   AnimatedCircularChart(
@@ -140,7 +149,7 @@ class _FavoriteClubCardState extends State<FavoriteClubCard> {
                   ),
                   (state is ClubStatsLoadedState)
                       ? RichText(
-                    textScaleFactor: 1.0,
+                          textScaleFactor: 1.0,
                           textAlign: TextAlign.center,
                           text: new TextSpan(
                             text: "${state.wonMatches}",
@@ -167,20 +176,13 @@ class _FavoriteClubCardState extends State<FavoriteClubCard> {
               children: <Widget>[
                 Expanded(
                   child: RichText(
-                    maxLines: 2,
-                    textAlign: TextAlign.right,
-                    textScaleFactor: 1.1,
-                    text: TextSpan(
-                      text: "X",
-                      style: TextStyle(
-                        fontSize: 24.0,
-                        fontWeight: FontWeight.bold
-                      ),
-                      children: [
-                        new TextSpan(text: " / y matchs à domicile", style: Theme.of(context).textTheme.body1)
-                      ]
-                    )
-                  ),
+                      maxLines: 2,
+                      textAlign: TextAlign.right,
+                      textScaleFactor: 1.1,
+                      text: TextSpan(
+                          text: "X",
+                          style: TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold),
+                          children: [new TextSpan(text: " / y matchs à domicile", style: Theme.of(context).textTheme.body1)])),
                 ),
               ],
             ),

--- a/lib/pages/find/find_page.dart
+++ b/lib/pages/find/find_page.dart
@@ -1,9 +1,0 @@
-import 'package:flutter/material.dart';
-import 'package:v34/pages/find/club_page.dart';
-
-class FindPage extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return ClubPage();
-  }
-}

--- a/lib/repositories/providers/favorite_provider.dart
+++ b/lib/repositories/providers/favorite_provider.dart
@@ -10,7 +10,9 @@ class FavoriteProvider {
 
   Future<List<String>> loadFavoriteClubs() async {
     await _localeStorage.ready;
-    return (_localeStorage.getItem(FavoriteClubKey) as List)?.cast<String>() ?? List();
+    var clubs = (_localeStorage.getItem(FavoriteClubKey) as List)?.cast<String>() ?? List();
+    print("Load favorite clubs $clubs");
+    return clubs;
   }
 
   Future<List<String>> loadFavoriteTeams() async {

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,4 +1,0 @@
-class Router {
-  static final String dashboard = "/";
-  static final String clubDetails = "/clubDetails";
-}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -155,6 +155,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
+  feature_discovery:
+    dependency: "direct main"
+    description:
+      name: feature_discovery
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.8.0"
   file:
     dependency: transitive
     description:
@@ -168,7 +175,7 @@ packages:
       name: fluid_bottom_nav_bar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1"
+    version: "1.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -211,6 +218,11 @@ packages:
     version: "0.17.4"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -445,11 +457,46 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.24.0"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.7+1"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+8"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2+5"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
+  smooth_page_indicator:
+    dependency: "direct main"
+    description:
+      name: smooth_page_indicator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   source_gen:
     dependency: transitive
     description:
@@ -578,4 +625,4 @@ packages:
     version: "2.2.0"
 sdks:
   dart: ">=2.7.0 <3.0.0"
-  flutter: ">=1.12.1 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   intl: ^0.16.1
   cupertino_icons: ^0.1.2
   dio: ^3.0.9
-  fluid_bottom_nav_bar: ^0.0.1
+  fluid_bottom_nav_bar: ^1.0.1
   flutter_svg: ^0.17.4
   flutter_staggered_animations: ^0.1.2
   localstorage: ^3.0.2+5
@@ -27,6 +27,9 @@ dependencies:
   timeline_list: ^0.0.5
   collection: ^1.14.11
   like_button: ^0.2.0
+  smooth_page_indicator: ^0.1.5
+  feature_discovery: ^0.8.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,0 +1,7 @@
+- Correction d'un bug sur les clubs favoris
+- Les clubs favoris sont classés par ordre dans lequel ils ont été sélectionnés
+- Liste des clubs favoris en 1er dans le dashboard
+- Ajout d'une animation lors du clic sur favori
+- Accès au détail d'un club depuis le dashboard en cliquant sur le club
+- Paging des clubs favoris avec un indicateur
+- Tour des fonctionnalités la 1ère fois que l'on arrive sur la page principale


### PR DESCRIPTION
- Fix issues in club favorite
- Favorite clubs are now sorted by the order they have been selected
- Favorite club list is now displayed first in the dashboard
- Add animation when a favorite is clicked
- Tap on a club (in the dashboard or in the club list) opens the club details
- If many favorite club then clubs are now displayed one by one (paging) with an indicator
- Feature displayed in the dashboard the first time it is opened
