### PR TITLE
Changed the color of the rounded network image in the RoundedTitledCard

### DIFF
--- a/lib/commons/cards/rounded_title_card.dart
+++ b/lib/commons/cards/rounded_title_card.dart
@@ -37,8 +37,8 @@ class RoundedTitledCard extends StatelessWidget {
               40,
               logoUrl,
               circleColor: TinyColor(Theme.of(context).cardTheme.color).isDark()
-                  ? TinyColor(Theme.of(context).cardTheme.color).lighten().color
-                  : TinyColor(Theme.of(context).cardTheme.color).darken().color,
+                  ? TinyColor(Theme.of(context).cardTheme.color).lighten(3).color
+                  : TinyColor(Theme.of(context).cardTheme.color).darken(3).color,
             ),
           ),
         )


### PR DESCRIPTION
Close #37 
The color of the rounded network image is now the same as the color of the card's title backgound (specified in the build method of TitledCard lines 32 and 33).