### PR TITLE
Added a smooth indicator to the team card page view

### DIFF
--- a/lib/pages/dashboard/dashboard_club_teams.dart
+++ b/lib/pages/dashboard/dashboard_club_teams.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:v34/commons/cards/titled_card.dart';
 import 'package:v34/commons/podium.dart';
 import 'package:v34/models/classication.dart';
@@ -79,17 +80,35 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: widget.cardHeight,
-      child: PageView.builder(
-        physics: const BouncingScrollPhysics(),
-        controller: _pageController,
-        itemCount: _teams.length,
-        itemBuilder: (context, index) {
-          var active = _currentIndex == index;
-          return _buildTeamCard(active, _teams[index], _pageController.page - index);
-        },
-      ),
+    return Column(
+      children: <Widget>[
+        Container(
+          height: widget.cardHeight,
+          child: PageView.builder(
+            physics: const BouncingScrollPhysics(),
+            controller: _pageController,
+            itemCount: _teams.length,
+            itemBuilder: (context, index) {
+              var active = _currentIndex == index;
+              return _buildTeamCard(active, _teams[index], _pageController.page - index);
+            },
+          )
+        ),
+        if (_teams.length > 1)
+          Padding(
+            padding: EdgeInsets.only(top: 16.0),
+            child: SmoothPageIndicator(
+              controller: _pageController,
+              count: _teams.length,
+              effect: WormEffect(
+                dotHeight: 8,
+                dotWidth: 8,
+                dotColor: Theme.of(context).cardTheme.color,
+                activeDotColor: Theme.of(context).accentColor,
+              )
+            ),
+          )
+      ]
     );
   }
 


### PR DESCRIPTION
Close #36 
A smooth indicator has been added under the team cards. Without additional style, the SmoothIndicator was stuck to the PageView. That's why I added a padding_top to the SmoothIndicator. This is not the way things were done for the club PageView, but the render still the same (see the joined screenshot). Is this a problem ?
![screenshot_padding_smoothindicator](https://user-images.githubusercontent.com/67117547/85401941-207dfb00-b55b-11ea-9186-082622430de7.jpg)
