### PR TITLE
Using of a different state management for each team card

### DIFF
--- a/lib/pages/dashboard/blocs/team_classification_bloc.dart
+++ b/lib/pages/dashboard/blocs/team_classification_bloc.dart
@@ -1,0 +1,69 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:v34/models/classication.dart';
+import 'package:v34/models/team.dart';
+import 'package:v34/repositories/repository.dart';
+
+// -- Events
+
+class TeamClassificationEvent extends Equatable {
+  final Team team;
+
+  const TeamClassificationEvent(this.team) : assert(team != null);
+
+  @override
+  List<Object> get props => [team];
+}
+
+class TeamClassificationLoadEvent extends TeamClassificationEvent {
+  TeamClassificationLoadEvent(Team team) : super(team);
+}
+
+// -- States
+
+class TeamClassificationState extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+class TeamClassificationUninitializedState extends TeamClassificationState {}
+
+class TeamClassificationLoadingState extends TeamClassificationState {}
+
+class TeamClassificationLoadedState extends TeamClassificationState {
+  final String highlightedTeamCode;
+  final List<ClassificationSynthesis> classifications;
+
+  TeamClassificationLoadedState(this.highlightedTeamCode, this.classifications);
+
+  @override
+  List<Object> get props => [highlightedTeamCode, classifications];
+}
+
+// -- Bloc
+
+class TeamClassificationBloc extends Bloc<TeamClassificationEvent, TeamClassificationState> {
+  final Repository repository;
+
+  TeamClassificationBloc({@required this.repository});
+
+  @override
+  TeamClassificationState get initialState => TeamClassificationUninitializedState();
+
+  @override
+  Stream<TeamClassificationState> mapEventToState(TeamClassificationEvent event) async* {
+    if (event is TeamClassificationLoadEvent) {
+      yield TeamClassificationLoadingState();
+      List<ClassificationSynthesis> classifications = await repository.loadTeamClassificationSynthesis(event.team.code);
+      classifications = classifications.map((classification) {
+        classification.teamsClassifications.sort((tc1, tc2) {
+          return tc1.rank.compareTo(tc2.rank) * -1;
+        });
+        return classification;
+      }).toList();
+      yield TeamClassificationLoadedState(event.team.code, classifications);
+    }
+  }
+
+}

--- a/lib/pages/dashboard/dashboard_club_teams.dart
+++ b/lib/pages/dashboard/dashboard_club_teams.dart
@@ -4,10 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
-import 'package:v34/commons/cards/titled_card.dart';
-import 'package:v34/commons/podium.dart';
-import 'package:v34/models/classication.dart';
 import 'package:v34/models/team.dart';
+import 'package:v34/pages/dashboard/team_card.dart';
 import 'package:v34/repositories/repository.dart';
 
 final Random random = Random.secure();
@@ -27,8 +25,6 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
   Repository _repository;
   List<Team> _teams = [];
   int _currentIndex = 0;
-  String _highlightedTeamCode;
-  List<ClassificationSynthesis> _competitionsClassificationSynthesis = [];
 
   @override
   void initState() {
@@ -36,13 +32,12 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
     _pageController = PageController(
       viewportFraction: 0.8,
     )..addListener(() {
-        var nextIndex = _pageController.page.round();
-        setState(() {});
-        if (nextIndex != _currentIndex) {
-          _currentIndex = nextIndex;
-          _loadTeamClassification(_teams[nextIndex].code);
-        }
-      });
+      var nextIndex = _pageController.page.round();
+      setState(() => {});
+      if (nextIndex != _currentIndex) {
+        _currentIndex = nextIndex;
+      }
+    });
     _loadTeams(widget.clubCode);
     super.initState();
   }
@@ -58,22 +53,6 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
       setState(() {
         _teams = teams;
         _pageController.jumpTo(0);
-        _loadTeamClassification(_teams[0].code);
-      });
-    });
-  }
-
-  _loadTeamClassification(String teamCode) {
-    print("====> TeamClass:$teamCode");
-    _repository.loadTeamClassificationSynthesis(teamCode).then((List<ClassificationSynthesis> classifications) {
-      setState(() {
-        _competitionsClassificationSynthesis = classifications.map((classification) {
-          classification.teamsClassifications.sort((tc1, tc2) {
-            return tc1.rank.compareTo(tc2.rank) * -1;
-          });
-          return classification;
-        }).toList();
-        _highlightedTeamCode = teamCode;
       });
     });
   }
@@ -89,8 +68,11 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
             controller: _pageController,
             itemCount: _teams.length,
             itemBuilder: (context, index) {
-              var active = _currentIndex == index;
-              return _buildTeamCard(active, _teams[index], _pageController.page - index);
+              return TeamCard(
+                currentlyDisplayed: _currentIndex == index,
+                team: _teams[index],
+                distance: _pageController.page - index,
+              );
             },
           )
         ),
@@ -112,37 +94,4 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
     );
   }
 
-  Widget _buildTeamCard(bool active, Team team, double distance) {
-    var absDistance = distance.abs() > 1 ? 1 : distance.abs();
-    final double cardBodyHeight = widget.cardHeight - 40;
-    return Transform.scale(
-      scale: 1.0 - (absDistance > 0.15 ? 0.15 : absDistance),
-      child: TitledCard(
-        margin: EdgeInsets.zero,
-        title: team.name,
-        bodyPadding: EdgeInsets.zero,
-        body: Container(
-          height: cardBodyHeight,
-          child: Row(children: [
-            ..._competitionsClassificationSynthesis.map((competitionClassificationSynthesis) {
-              var placeValues = competitionClassificationSynthesis.teamsClassifications.map((teamClassification) {
-                return PlaceValue(teamClassification.teamCode, teamClassification.totalPoints.toDouble());
-              }).toList();
-              var highlightedIndex = placeValues.indexWhere((placeValue) => placeValue.id == _highlightedTeamCode);
-              return Expanded(
-                child: Podium(
-                  placeValues,
-                  active: active,
-                  title: competitionClassificationSynthesis.label,
-                  highlightedIndex: highlightedIndex,
-                  promoted: competitionClassificationSynthesis.promoted,
-                  relegated: competitionClassificationSynthesis.relegated,
-                ),
-              );
-            })
-          ]),
-        ),
-      ),
-    );
-  }
 }

--- a/lib/pages/dashboard/team_card.dart
+++ b/lib/pages/dashboard/team_card.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:v34/commons/cards/titled_card.dart';
+import 'package:v34/commons/podium.dart';
+import 'package:v34/models/team.dart';
+import 'package:v34/pages/dashboard/blocs/team_classification_bloc.dart';
+import 'package:v34/repositories/repository.dart';
+
+class TeamCard extends StatefulWidget {
+  final Team team;
+  final bool currentlyDisplayed;
+  final double distance;
+  final double cardHeight = 190;
+
+  TeamCard({@required this.team, @required this.currentlyDisplayed, @required this.distance});
+
+  @override
+  _TeamCardState createState() => _TeamCardState();
+
+}
+
+class _TeamCardState extends State<TeamCard> {
+  TeamClassificationBloc _classificationBloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _classificationBloc = TeamClassificationBloc(
+      repository: RepositoryProvider.of<Repository>(context)
+    );
+    if (widget.currentlyDisplayed) {
+      _classificationBloc.add(TeamClassificationLoadEvent(widget.team));
+    }
+  }
+
+  @override
+  void didUpdateWidget(TeamCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // !oldWidget.active -> to avoid several calls to the API when sliding
+    // which can create a visual bug
+    if (widget.currentlyDisplayed && ((widget.team.clubCode != oldWidget.team.clubCode) || !oldWidget.currentlyDisplayed)) {
+      _classificationBloc.add(TeamClassificationLoadEvent(widget.team));
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _classificationBloc.close();
+  }
+
+  List<Widget> _getPodiumWidget(state) {
+    if (state is TeamClassificationLoadedState) {
+      return state.classifications.map((competitionClassificationSynthesis) {
+        var placeValues = competitionClassificationSynthesis.teamsClassifications.map((teamClassification) {
+          return PlaceValue(teamClassification.teamCode, teamClassification.totalPoints.toDouble());
+        }).toList();
+        var highlightedIndex = placeValues.indexWhere((placeValue) => placeValue.id == state.highlightedTeamCode);
+        return Expanded(
+          child: Podium(
+            placeValues,
+            active: widget.currentlyDisplayed,
+            title: competitionClassificationSynthesis.label,
+            highlightedIndex: highlightedIndex,
+            promoted: competitionClassificationSynthesis.promoted,
+            relegated: competitionClassificationSynthesis.relegated,
+          ),
+        );
+      }).toList();
+    } else {
+      return [];
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var absDistance = widget.distance.abs() > 1 ? 1 : widget.distance.abs();
+    final double cardBodyHeight = widget.cardHeight - 40;
+    return BlocBuilder<TeamClassificationBloc, TeamClassificationState>(
+      bloc: _classificationBloc,
+      builder: (context, state) {
+        return Transform.scale(
+          scale: 1.0 - (absDistance > 0.15 ? 0.15 : absDistance),
+          child: TitledCard(
+            margin: EdgeInsets.zero,
+            title: widget.team.name,
+            bodyPadding: EdgeInsets.zero,
+            body: Container(
+              height: cardBodyHeight,
+              child: Row(children: _getPodiumWidget(state)),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+}

--- a/lib/pages/dashboard/team_card.dart
+++ b/lib/pages/dashboard/team_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:v34/commons/cards/titled_card.dart';
+import 'package:v34/commons/loading.dart';
 import 'package:v34/commons/podium.dart';
 import 'package:v34/models/team.dart';
 import 'package:v34/pages/dashboard/blocs/team_classification_bloc.dart';
@@ -49,9 +50,18 @@ class _TeamCardState extends State<TeamCard> {
     _classificationBloc.close();
   }
 
+  Widget _noPodiumData() {
+    return Expanded(
+      child: Text(
+        'Aucunes données...',
+        textAlign: TextAlign.center
+      )
+    );
+  }
+
   List<Widget> _getPodiumWidget(state) {
     if (state is TeamClassificationLoadedState) {
-      return state.classifications.map((competitionClassificationSynthesis) {
+      List<Widget> result = state.classifications.map((competitionClassificationSynthesis) {
         var placeValues = competitionClassificationSynthesis.teamsClassifications.map((teamClassification) {
           return PlaceValue(teamClassification.teamCode, teamClassification.totalPoints.toDouble());
         }).toList();
@@ -67,6 +77,10 @@ class _TeamCardState extends State<TeamCard> {
           ),
         );
       }).toList();
+      if(result.isEmpty) result.add(_noPodiumData());
+      return result;
+    } else if (state is TeamClassificationLoadingState) {
+      return [Expanded(child: Loading())];
     } else {
       return [];
     }

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,7 +1,1 @@
-- Correction d'un bug sur les clubs favoris
-- Les clubs favoris sont classés par ordre dans lequel ils ont été sélectionnés
-- Liste des clubs favoris en 1er dans le dashboard
-- Ajout d'une animation lors du clic sur favori
-- Accès au détail d'un club depuis le dashboard en cliquant sur le club
-- Paging des clubs favoris avec un indicateur
-- Tour des fonctionnalités la 1ère fois que l'on arrive sur la page principale
+- Correction d'un bug sur l'affichage des statistiques des équipes sur le dashboard.


### PR DESCRIPTION
Close #34 
Team cards have now their own state. I used a Bloc to manage these states. The code is quite dirty (using of two lists which have to be coherent) and could be improved (I thought about a Map but it creates a bug). A loader is missing to indicate the data is being retrieved.