### PR TITLE
Define the color of the card's title background in an extension of CardTheme

### DIFF
--- a/lib/commons/cards/rounded_title_card.dart
+++ b/lib/commons/cards/rounded_title_card.dart
@@ -1,11 +1,9 @@
-
-
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:tinycolor/tinycolor.dart';
 import 'package:v34/commons/cards/titled_card.dart';
 import 'package:v34/commons/rounded_network_image.dart';
+import 'package:v34/utils/extensions.dart';
 
 class RoundedTitledCard extends StatelessWidget {
 
@@ -36,9 +34,7 @@ class RoundedTitledCard extends StatelessWidget {
             child: RoundedNetworkImage(
               40,
               logoUrl,
-              circleColor: TinyColor(Theme.of(context).cardTheme.color).isDark()
-                  ? TinyColor(Theme.of(context).cardTheme.color).lighten(3).color
-                  : TinyColor(Theme.of(context).cardTheme.color).darken(3).color,
+              circleColor: Theme.of(context).cardTheme.titleBackgroundColor(context)
             ),
           ),
         )

--- a/lib/commons/cards/titled_card.dart
+++ b/lib/commons/cards/titled_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tinycolor/tinycolor.dart';
+import 'package:v34/utils/extensions.dart';
 
 class TitledCard extends StatelessWidget {
   final Widget icon;
@@ -28,9 +29,7 @@ class TitledCard extends StatelessWidget {
               children: [
                 Container(
                   decoration: BoxDecoration(
-                    color: TinyColor(Theme.of(context).cardTheme.color).isDark()
-                        ? TinyColor(Theme.of(context).cardTheme.color).lighten(3).color
-                        : TinyColor(Theme.of(context).cardTheme.color).darken(3).color,
+                    color: Theme.of(context).cardTheme.titleBackgroundColor(context)
                   ),
                   height: 40,
                   child: Padding(

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -1,7 +1,6 @@
-
-
 import 'dart:ui';
 
+import 'package:flutter/material.dart';
 import 'package:tinycolor/tinycolor.dart';
 
 extension Extension on String {
@@ -19,4 +18,12 @@ extension TinyColorExtension on Color {
   }
 
   Color smallTiny() => this.tiny(3);
+}
+
+extension CustomCardTheme on CardTheme {
+  Color titleBackgroundColor(BuildContext context) {
+    return TinyColor(Theme.of(context).cardTheme.color).isDark()
+        ? TinyColor(Theme.of(context).cardTheme.color).lighten(3).color
+        :	TinyColor(Theme.of(context).cardTheme.color).darken(3).color;
+  }
 }

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,1 +1,1 @@
-- Correction d'un bug sur le dashboard faisant que le club et l'équipe actuels n'étaient pas enregistrés quand on défilait vers l'agenda.
+


### PR DESCRIPTION
Close #44
I used `extension` of `CardTheme` instead of creating a subclass because it seems better in term of usage in the client code (no cast).