### PR TITLE
Reduce white spaces between elements in the dashboard

### DIFF
--- a/lib/commons/paragraph.dart
+++ b/lib/commons/paragraph.dart
@@ -10,7 +10,7 @@ class Paragraph extends StatelessWidget {
   final double topPadding;
   final double bottomPadding;
 
-  Paragraph({this.title, this.child, this.topPadding = 20.0, this.bottomPadding = 20.0});
+  Paragraph({this.title, this.child, this.topPadding = 20.0, this.bottomPadding = 0.0});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/commons/paragraph.dart
+++ b/lib/commons/paragraph.dart
@@ -8,13 +8,14 @@ class Paragraph extends StatelessWidget {
   final String title;
   final Widget child;
   final double topPadding;
+  final double bottomPadding;
 
-  Paragraph({this.title, this.child, double topPadding}): this.topPadding = topPadding ?? 44.0;
+  Paragraph({this.title, this.child, this.topPadding = 20.0, this.bottomPadding = 20.0});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 18.0, right: 8.0, top: topPadding, bottom: 28.0),
+      padding: EdgeInsets.only(left: 18.0, right: 8.0, top: topPadding, bottom: bottomPadding),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -94,7 +94,6 @@ class _DashboardPageState extends State<DashboardPage> {
       case 0:
         return Paragraph(
           title: state.clubs.length > 1 ? "Vos clubs" : "Votre club",
-          bottomPadding: 0.0,
         );
       case 1:
         return (state is FavoriteLoadedState)
@@ -131,13 +130,15 @@ class _DashboardPageState extends State<DashboardPage> {
                 child: Center(child: Loading()),
               );
       case 2:
-        return Paragraph(title: state.teamCodes.length > 1 ? "Vos équipes" : "Vos équipes");
+        return Paragraph(
+          title: state.teamCodes.length > 1 ? "Vos équipes" : "Vos équipes",
+          bottomPadding: 20.0,
+        );
       case 3:
         return DashboardClubTeams(clubCode: _currentClubCode);
       case 4:
         return Paragraph(
           title: "Votre agenda",
-          bottomPadding: 0.0,
         );
       case 5:
         return BlocBuilder(

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -92,7 +92,10 @@ class _DashboardPageState extends State<DashboardPage> {
   Widget _buildDashboardItem(int index, FavoriteState state) {
     switch (index) {
       case 0:
-        return Paragraph(title: state.clubs.length > 1 ? "Vos clubs" : "Votre club");
+        return Paragraph(
+          title: state.clubs.length > 1 ? "Vos clubs" : "Votre club",
+          bottomPadding: 0.0,
+        );
       case 1:
         return (state is FavoriteLoadedState)
             ? Column(
@@ -132,7 +135,10 @@ class _DashboardPageState extends State<DashboardPage> {
       case 3:
         return DashboardClubTeams(clubCode: _currentClubCode);
       case 4:
-        return Paragraph(title: "Votre agenda");
+        return Paragraph(
+          title: "Votre agenda",
+          bottomPadding: 0.0,
+        );
       case 5:
         return BlocBuilder(
             bloc: _agendaBloc,


### PR DESCRIPTION
Close #48 
I added a field in the `Paragraph` class ("Vos clubs", "Vos équipes" elements) to be able to choose the bottom padding. Then I reduced top and bottom padding of paragraphs in the dashboard (see the picture joined).

The second step will be to make disappear the bottom bar when the user is not scrolling.

What do you think for now ?

<img src="https://user-images.githubusercontent.com/67117547/85945280-04080700-b93d-11ea-9428-8d946ea1b16e.jpg" height=400>