### PR TITLE
Correct team card animation

### DIFF
--- a/lib/pages/dashboard/dashboard_club_teams.dart
+++ b/lib/pages/dashboard/dashboard_club_teams.dart
@@ -24,6 +24,7 @@ class DashboardClubTeams extends StatefulWidget {
 class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTickerProviderStateMixin {
   PageController _pageController;
   int _currentIndex = 0;
+  double _currentTeamPage = 0;
   ClubTeamsBloc _clubTeamsBloc;
 
   @override
@@ -32,7 +33,7 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
       viewportFraction: 0.8,
     )..addListener(() {
       var nextIndex = _pageController.page.round();
-      setState(() => {});
+      setState(() => _currentTeamPage = _pageController.page);
       if (nextIndex != _currentIndex) {
         _currentIndex = nextIndex;
       }
@@ -76,7 +77,7 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
                         return TeamCard(
                           currentlyDisplayed: _currentIndex == index,
                           team: state.teams[index],
-                          distance: (_currentIndex - index).toDouble(),
+                          distance: _currentTeamPage - index,
                         );
                       },
                     )

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,1 +1,1 @@
-- Modification de l'indicateur de chargement lors de la récupération des statistiques d'une équipe sur le dashboard.
+- Correction d'un bug d'animation des cartes d'équipes sur le dashboard.


### PR DESCRIPTION
I introduced a bug on the animation of team cards on the PR #53.
It's now corrected.