### PR TITLE
Add a switch theme option on the dashboard

### DIFF
--- a/lib/commons/podium.dart
+++ b/lib/commons/podium.dart
@@ -208,7 +208,7 @@ class _PodiumState extends State<Podium> {
             ) {
               return BarTooltipItem(
                 showToolTip ? places[groupIndex].tooltip : "",
-                TextStyle(color: Colors.white, fontSize: 10, fontFamily: "Raleway"),
+                TextStyle(color: Theme.of(context).textTheme.bodyText1.color, fontSize: 10, fontFamily: "Raleway"),
               );
             },
           ),

--- a/lib/commons/rounded_network_image.dart
+++ b/lib/commons/rounded_network_image.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:v34/utils/extensions.dart';
 
 class RoundedNetworkImage extends StatelessWidget {
   final double size;
@@ -22,7 +23,7 @@ class RoundedNetworkImage extends StatelessWidget {
       child: Container(
         decoration: BoxDecoration(
           shape: BoxShape.circle,
-          color: Theme.of(context).bottomAppBarColor,
+          color: Theme.of(context).cardTheme.titleBackgroundColor(context),
         ),
         child: Padding(
           padding: const EdgeInsets.all(4.0),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,25 +40,12 @@ class V34 extends StatefulWidget {
 }
 
 class _V34State extends State<V34> {
-  Future<SharedPreferences> _preferences;
-
-  @override
-  void initState() {
-    super.initState();
-    _preferences = SharedPreferences.getInstance();
-  }
+  Future<SharedPreferences> _preferences = SharedPreferences.getInstance();
 
   ThemeData _getTheme(AsyncSnapshot<SharedPreferences> snapshot) {
     bool automatic = snapshot.data.getBool("automatic_dark_theme") ?? false;
     bool dark = snapshot.data.getBool("dark_theme") ?? false;
-    DateTime now = DateTime.now();
-    if (automatic) {
-      if (now.hour >= 20 || now.hour < 8) return AppTheme.darkTheme();
-      else return AppTheme.lightTheme();
-    } else {
-      if (dark) return AppTheme.darkTheme();
-      else return AppTheme.lightTheme();
-    }
+    return AppTheme.getThemeFromPreferences(automatic, dark);
   }
   
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:animated_theme_switcher/animated_theme_switcher.dart';
 import 'package:bloc/bloc.dart';
 import 'package:feature_discovery/feature_discovery.dart';
 import 'package:fluid_bottom_nav_bar/fluid_bottom_nav_bar.dart';
@@ -28,20 +29,18 @@ void main() {
 
 class V34 extends StatefulWidget {
   @override
-  V34State createState() => V34State();
+  _V34State createState() => _V34State();
 
   static String _pkg = "mobile";
 
   static String get pkg => Env.getPackage(_pkg);
 }
 
-class V34State extends State<V34> {
-  ThemeData theme;
+class _V34State extends State<V34> {
 
   @override
   void initState() {
     super.initState();
-    theme = AppTheme.lightTheme();
   }
 
   @override
@@ -55,10 +54,15 @@ class V34State extends State<V34> {
         GymnasiumProvider(),
       ),
       child: FeatureDiscovery(
-        child: MaterialApp(
-          title: 'Volley34',
-          theme: theme,
-          home: _MainPage(),
+        child: ThemeProvider(
+          initTheme: AppTheme.lightTheme(),
+          child: Builder(builder: (context) {
+            return MaterialApp(
+              title: 'Volley34',
+              theme: ThemeProvider.of(context),
+              home: _MainPage(),
+            );
+          }),
         ),
       ),
     );
@@ -96,58 +100,62 @@ class __MainPageState extends State<_MainPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Theme.of(context).primaryColor,
-      extendBody: true,
-      body: _child,
-      bottomNavigationBar: FluidNavBar(
-        icons: [
-          FluidNavBarIcon(iconPath: "assets/dashboard.svg", extras: {
-            "featureId": "dashboard_feature_id",
-            "title": "Tableau de bord",
-            "paragraphs": [
-              "L'ensemble de vos clubs et équipes favorites toujours à portée.",
-              "Retrouvez votre agenda, des statistiques et l'ensemble des informations utiles au jour le jour."
+    return ThemeSwitchingArea(
+      child: Builder(builder: (context) {
+        return Scaffold(
+          backgroundColor: Theme.of(context).primaryColor,
+          extendBody: true,
+          body: _child,
+          bottomNavigationBar: FluidNavBar(
+            icons: [
+              FluidNavBarIcon(iconPath: "assets/dashboard.svg", extras: {
+                "featureId": "dashboard_feature_id",
+                "title": "Tableau de bord",
+                "paragraphs": [
+                  "L'ensemble de vos clubs et équipes favorites toujours à portée.",
+                  "Retrouvez votre agenda, des statistiques et l'ensemble des informations utiles au jour le jour."
+                ],
+              }),
+              FluidNavBarIcon(iconPath: "assets/competition-filled.svg", extras: {
+                "featureId": "competition_feature_id",
+                "title": "Compétitions",
+                "paragraphs": [
+                  "Championnats, Challenges et Coupe de printemps.",
+                  "L'ensemble des résultats, classements par catégorie, poule et type de compétition."
+                ],
+              }),
+              FluidNavBarIcon(iconPath: "assets/shield.svg", extras: {
+                "featureId": "clubs_feature_id",
+                "title": "Liste des clubs",
+                "paragraphs": [
+                  "Accédez à l'ensemble des clubs inscrits aux compétitions.",
+                  "Sélectionnez un ou plusieurs favoris, ainsi accédez rapidement depuis le tableau de bord à des informations importantes sur vos favoris."
+                ],
+              }),
             ],
-          }),
-          FluidNavBarIcon(iconPath: "assets/competition-filled.svg", extras: {
-            "featureId": "competition_feature_id",
-            "title": "Compétitions",
-            "paragraphs": [
-              "Championnats, Challenges et Coupe de printemps.",
-              "L'ensemble des résultats, classements par catégorie, poule et type de compétition."
-            ],
-          }),
-          FluidNavBarIcon(iconPath: "assets/shield.svg", extras: {
-            "featureId": "clubs_feature_id",
-            "title": "Liste des clubs",
-            "paragraphs": [
-              "Accédez à l'ensemble des clubs inscrits aux compétitions.",
-              "Sélectionnez un ou plusieurs favoris, ainsi accédez rapidement depuis le tableau de bord à des informations importantes sur vos favoris."
-            ],
-          }),
-        ],
-        style: FluidNavBarStyle(
-          barBackgroundColor: Theme.of(context).bottomAppBarColor,
-          iconSelectedForegroundColor: Color(0xFF313852),
-          iconUnselectedForegroundColor: Theme.of(context).tabBarTheme.unselectedLabelColor,
-        ),
-        scaleFactor: 1.4,
-        onChange: _handleNavigationChange,
-        itemBuilder: (icon, item) {
-          return FeatureTour(
-            child: item,
-            featureId: icon.extras["featureId"],
-            title: icon.extras["title"],
-            paragraphs: icon.extras["paragraphs"] ?? [],
-            target: SvgPicture.asset(
-              icon.iconPath,
-              height: 30,
-              color: Theme.of(context).tabBarTheme.unselectedLabelColor,
+            style: FluidNavBarStyle(
+              barBackgroundColor: Theme.of(context).bottomAppBarColor,
+              iconSelectedForegroundColor: Color(0xFF313852),
+              iconUnselectedForegroundColor: Theme.of(context).tabBarTheme.unselectedLabelColor,
             ),
-          );
-        },
-      ),
+            scaleFactor: 1.4,
+            onChange: _handleNavigationChange,
+            itemBuilder: (icon, item) {
+              return FeatureTour(
+                child: item,
+                featureId: icon.extras["featureId"],
+                title: icon.extras["title"],
+                paragraphs: icon.extras["paragraphs"] ?? [],
+                target: SvgPicture.asset(
+                  icon.iconPath,
+                  height: 30,
+                  color: Theme.of(context).tabBarTheme.unselectedLabelColor,
+                ),
+              );
+            },
+          ),
+        );
+      })
     );
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,7 @@ class _V34State extends State<V34> {
       child: FeatureDiscovery(
         child: MaterialApp(
           title: 'Volley34',
-          theme: AppTheme.theme(),
+          theme: AppTheme.lightTheme(),
           home: _MainPage(),
         ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,6 +47,19 @@ class _V34State extends State<V34> {
     super.initState();
     _preferences = SharedPreferences.getInstance();
   }
+
+  ThemeData _getTheme(AsyncSnapshot<SharedPreferences> snapshot) {
+    bool automatic = snapshot.data.getBool("automatic_dark_theme") ?? false;
+    bool dark = snapshot.data.getBool("dark_theme") ?? false;
+    DateTime now = DateTime.now();
+    if (automatic) {
+      if (now.hour >= 20 || now.hour < 8) return AppTheme.darkTheme();
+      else return AppTheme.lightTheme();
+    } else {
+      if (dark) return AppTheme.darkTheme();
+      else return AppTheme.lightTheme();
+    }
+  }
   
   @override
   Widget build(BuildContext context) {
@@ -77,9 +90,7 @@ class _V34State extends State<V34> {
               ),
               child: FeatureDiscovery(
                 child: ThemeProvider(
-                  initTheme: snapshot.data.getBool("dark_theme")
-                      ? AppTheme.darkTheme()
-                      : AppTheme.lightTheme(),
+                  initTheme: _getTheme(snapshot),
                   child: Builder(builder: (context) {
                     return MaterialApp(
                       title: 'Volley34',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,12 +37,7 @@ class V34 extends StatefulWidget {
 }
 
 class _V34State extends State<V34> {
-
-  @override
-  void initState() {
-    super.initState();
-  }
-
+  
   @override
   Widget build(BuildContext context) {
     return RepositoryProvider(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,14 +28,22 @@ void main() {
 
 class V34 extends StatefulWidget {
   @override
-  _V34State createState() => _V34State();
+  V34State createState() => V34State();
 
   static String _pkg = "mobile";
 
   static String get pkg => Env.getPackage(_pkg);
 }
 
-class _V34State extends State<V34> {
+class V34State extends State<V34> {
+  ThemeData theme;
+
+  @override
+  void initState() {
+    super.initState();
+    theme = AppTheme.lightTheme();
+  }
+
   @override
   Widget build(BuildContext context) {
     return RepositoryProvider(
@@ -49,7 +57,7 @@ class _V34State extends State<V34> {
       child: FeatureDiscovery(
         child: MaterialApp(
           title: 'Volley34',
-          theme: AppTheme.lightTheme(),
+          theme: theme,
           home: _MainPage(),
         ),
       ),

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -66,47 +66,19 @@ class _DashboardPageState extends State<DashboardPage> {
       create: (context) => _favoriteBloc,
       child: BlocBuilder<FavoriteBloc, FavoriteState>(
         builder: (context, state) {
-          return Builder(builder: (context) {
-              return Stack(
-                children: <Widget>[
-                  (state is FavoriteLoadedState)
-                      ? ListView.builder(
-                    shrinkWrap: true,
-                    itemCount: 6,
-                    itemBuilder: (context, index) {
-                      return _buildDashboardItem(
-                        index,
-                        state,
-                      );
-                    },
-                  )
-                      : SizedBox(),
-                  Positioned(
-                    top: 40.0,
-                    right: 8.0,
-                    child: ThemeSwitcher(
-                      clipper: ThemeSwitcherCircleClipper(),
-                      builder: (context) {
-                        return Switch(
-                          value: _isDarkActive,
-                          onChanged: (value) {
-                            setState(() => _isDarkActive = value);
-                            if (_isDarkActive) {
-                              ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
-                            } else {
-                              ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
-                            }
-                          },
-                        );
-                      },
-                    )
-                  )
-                ],
-              );
-            }
-          );
-        },
-      ),
+          return (state is FavoriteLoadedState)
+            ? ListView.builder(
+              shrinkWrap: true,
+              itemCount: 6,
+              itemBuilder: (context, index) {
+                return _buildDashboardItem(
+                  index,
+                  state,
+                );
+              },
+          ) : SizedBox();
+        }
+      )
     );
   }
 
@@ -126,8 +98,32 @@ class _DashboardPageState extends State<DashboardPage> {
   Widget _buildDashboardItem(int index, FavoriteState state) {
     switch (index) {
       case 0:
-        return Paragraph(
-          title: state.clubs.length > 1 ? "Vos clubs" : "Votre club",
+        return Stack(
+          children: <Widget>[
+            Paragraph(
+              title: state.clubs.length > 1 ? "Vos clubs" : "Votre club",
+            ),
+            Positioned(
+                right: 10.0,
+                top: 2.0,
+                child: ThemeSwitcher(
+                  clipper: ThemeSwitcherCircleClipper(),
+                  builder: (context) {
+                    return Switch(
+                      value: _isDarkActive,
+                      onChanged: (value) {
+                        setState(() => _isDarkActive = value);
+                        if (_isDarkActive) {
+                          ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
+                        } else {
+                          ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
+                        }
+                      },
+                    );
+                  },
+                )
+            )
+          ],
         );
       case 1:
         return (state is FavoriteLoadedState)

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -69,9 +69,9 @@ class _DashboardPageState extends State<DashboardPage> {
                 pinned: false,
                 snap: false,
                 floating: true,
-                title: Text('Tableau de bord'),
+                title: Text('Volley34'),
                 actions: <Widget>[
-                  IconButton(icon: Icon(Icons.settings), onPressed: _pushPreferences)
+                  IconButton(icon: Icon(Icons.settings), onPressed: _gotoPreferencesPage)
                 ],
               ),
               _buildSliverList(state)
@@ -82,7 +82,7 @@ class _DashboardPageState extends State<DashboardPage> {
     );
   }
 
-  void _pushPreferences() {
+  void _gotoPreferencesPage() {
     Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (context) => PreferencesPage()

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:v34/commons/loading.dart';
 import 'package:v34/commons/router.dart';
+import 'package:v34/main.dart';
 import 'package:v34/pages/club-details/club_detail_page.dart';
 import 'package:v34/pages/dashboard/blocs/agenda_bloc.dart';
 import 'package:v34/pages/dashboard/blocs/favorite_bloc.dart';
@@ -13,6 +14,7 @@ import 'package:v34/pages/dashboard/fav_club_card.dart';
 import 'package:v34/pages/dashboard/widgets/timeline/timeline.dart';
 import 'package:v34/pages/dashboard/widgets/timeline/timeline_items.dart';
 import 'package:v34/repositories/repository.dart';
+import 'package:v34/theme.dart';
 
 class DashboardPage extends StatefulWidget {
   final double cardHeight = 250;
@@ -27,10 +29,12 @@ class _DashboardPageState extends State<DashboardPage> {
   PageController _pageController;
   String _currentClubCode;
   double currentFavoriteClubPage = 0;
+  bool _isDarkActive;
 
   @override
   void initState() {
     super.initState();
+    _isDarkActive = false;
     _favoriteBloc = FavoriteBloc(repository: RepositoryProvider.of<Repository>(context))..add(FavoriteLoadEvent());
     _favoriteBloc.skip(1).listen((state) {
       if (state is FavoriteLoadedState) {
@@ -61,18 +65,42 @@ class _DashboardPageState extends State<DashboardPage> {
       create: (context) => _favoriteBloc,
       child: BlocBuilder<FavoriteBloc, FavoriteState>(
         builder: (context, state) {
-          return (state is FavoriteLoadedState)
-              ? ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: 6,
-                  itemBuilder: (context, index) {
-                    return _buildDashboardItem(
-                      index,
-                      state,
-                    );
+          return Stack(
+            children: <Widget>[
+              (state is FavoriteLoadedState)
+                ? ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: 6,
+                    itemBuilder: (context, index) {
+                      return _buildDashboardItem(
+                        index,
+                        state,
+                      );
+                    },
+                  )
+                : SizedBox(),
+              Positioned(
+                top: 40.0,
+                right: 8.0,
+                child: Switch(
+                  value: _isDarkActive,
+                  onChanged: (value) {
+                    setState(() => _isDarkActive = value);
+                    var v34State = context.findAncestorStateOfType<V34State>();
+                    if (_isDarkActive) {
+                      v34State.setState(() {
+                        v34State.theme = AppTheme.darkTheme();
+                      });
+                    } else {
+                      v34State.setState(() {
+                        v34State.theme = AppTheme.lightTheme();
+                      });
+                    }
                   },
-                )
-              : SizedBox();
+                ),
+              )
+            ],
+          );
         },
       ),
     );

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:v34/commons/loading.dart';
 import 'package:v34/commons/router.dart';
-import 'package:v34/main.dart';
 import 'package:v34/pages/club-details/club_detail_page.dart';
 import 'package:v34/pages/dashboard/blocs/agenda_bloc.dart';
 import 'package:v34/pages/dashboard/blocs/favorite_bloc.dart';

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -71,7 +71,7 @@ class _DashboardPageState extends State<DashboardPage> {
                 floating: true,
                 title: Text('Tableau de bord'),
                 actions: <Widget>[
-                  IconButton(icon: Icon(Icons.build), onPressed: _pushPreferences)
+                  IconButton(icon: Icon(Icons.settings), onPressed: _pushPreferences)
                 ],
               ),
               _buildSliverList(state)

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -1,3 +1,4 @@
+import 'package:animated_theme_switcher/animated_theme_switcher.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -65,10 +66,11 @@ class _DashboardPageState extends State<DashboardPage> {
       create: (context) => _favoriteBloc,
       child: BlocBuilder<FavoriteBloc, FavoriteState>(
         builder: (context, state) {
-          return Stack(
-            children: <Widget>[
-              (state is FavoriteLoadedState)
-                ? ListView.builder(
+          return Builder(builder: (context) {
+              return Stack(
+                children: <Widget>[
+                  (state is FavoriteLoadedState)
+                      ? ListView.builder(
                     shrinkWrap: true,
                     itemCount: 6,
                     itemBuilder: (context, index) {
@@ -78,28 +80,30 @@ class _DashboardPageState extends State<DashboardPage> {
                       );
                     },
                   )
-                : SizedBox(),
-              Positioned(
-                top: 40.0,
-                right: 8.0,
-                child: Switch(
-                  value: _isDarkActive,
-                  onChanged: (value) {
-                    setState(() => _isDarkActive = value);
-                    var v34State = context.findAncestorStateOfType<V34State>();
-                    if (_isDarkActive) {
-                      v34State.setState(() {
-                        v34State.theme = AppTheme.darkTheme();
-                      });
-                    } else {
-                      v34State.setState(() {
-                        v34State.theme = AppTheme.lightTheme();
-                      });
-                    }
-                  },
-                ),
-              )
-            ],
+                      : SizedBox(),
+                  Positioned(
+                    top: 40.0,
+                    right: 8.0,
+                    child: ThemeSwitcher(
+                      clipper: ThemeSwitcherCircleClipper(),
+                      builder: (context) {
+                        return Switch(
+                          value: _isDarkActive,
+                          onChanged: (value) {
+                            setState(() => _isDarkActive = value);
+                            if (_isDarkActive) {
+                              ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
+                            } else {
+                              ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
+                            }
+                          },
+                        );
+                      },
+                    )
+                  )
+                ],
+              );
+            }
           );
         },
       ),

--- a/lib/pages/dashboard/fav_club_card.dart
+++ b/lib/pages/dashboard/fav_club_card.dart
@@ -153,7 +153,7 @@ class _FavoriteClubCardState extends State<FavoriteClubCard> with AutomaticKeepA
                       textScaleFactor: 1.1,
                       text: TextSpan(
                           text: "X",
-                          style: TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold),
+                          style: TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold, color: Theme.of(context).textTheme.bodyText2.color),
                           children: [new TextSpan(text: " / y matchs à domicile", style: Theme.of(context).textTheme.bodyText2)])),
                 ),
               ],

--- a/lib/pages/preferences_page.dart
+++ b/lib/pages/preferences_page.dart
@@ -1,0 +1,87 @@
+import 'package:animated_theme_switcher/animated_theme_switcher.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:v34/commons/loading.dart';
+import 'package:v34/theme.dart';
+
+class PreferencesPage extends StatefulWidget {
+  @override
+  _PreferencesPageState createState() => _PreferencesPageState();
+}
+
+class _PreferencesPageState extends State<PreferencesPage> {
+  Future<SharedPreferences> _preferences;
+
+  @override
+  void initState() {
+    _preferences = SharedPreferences.getInstance();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ThemeSwitchingArea(
+      child: Scaffold(
+        backgroundColor: Theme.of(context).primaryColor,
+        appBar: AppBar(title: Text("Préférences")),
+        body: _buildPreferencesContent(),
+      ),
+    );
+  }
+
+  Widget _buildPreferencesContent() {
+    return FutureBuilder<SharedPreferences>(
+      future: _preferences,
+      builder: (context, snapshot) {
+        switch (snapshot.connectionState) {
+          case ConnectionState.waiting:
+            return Center(
+              child: Column(
+                children: <Widget>[
+                  Text("Chargement de vos préférences..."),
+                  Loading()
+                ]
+              ),
+            );
+          case ConnectionState.done:
+            return ListView.builder(
+              itemBuilder: (context, index) => _buildPreferencesItem(index, snapshot),
+            );
+          default:
+            return Container();
+        }
+      },
+    );
+  }
+
+  Widget _buildPreferencesItem(int index, AsyncSnapshot<SharedPreferences> snapshot) {
+    if (index % 2 == 0) {
+      index = index ~/ 2;
+      switch (index) {
+        case 0:
+          return ThemeSwitcher(
+            clipper: ThemeSwitcherCircleClipper(),
+            builder: (context) {
+              return SwitchListTile(
+                title: Text("Thème sombre", style: Theme.of(context).textTheme.bodyText2),
+                secondary: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
+                value: snapshot.data.getBool('dark_theme') ?? false,
+                onChanged: (dark) {
+                  if (dark) {
+                    ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
+                  } else {
+                    ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
+                  }
+                  snapshot.data.setBool('dark_theme', dark);
+                },
+              );
+            },
+          );
+        default:
+          return null;
+      }
+    } else {
+      return Divider();
+    }
+  }
+
+}

--- a/lib/pages/preferences_page.dart
+++ b/lib/pages/preferences_page.dart
@@ -14,6 +14,7 @@ class _PreferencesPageState extends State<PreferencesPage> {
 
   @override
   void initState() {
+    super.initState();
     _preferences = SharedPreferences.getInstance();
   }
 
@@ -61,18 +62,40 @@ class _PreferencesPageState extends State<PreferencesPage> {
           return ThemeSwitcher(
             clipper: ThemeSwitcherCircleClipper(),
             builder: (context) {
+              bool automaticDarkTheme = snapshot.data.getBool('automatic_dark_theme') ?? false;
+              if (automaticDarkTheme) {
+                return ListTile(
+                  title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
+                  leading: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
+                  trailing: Text(
+                    "Mode sombre automatique activé",
+                    style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10),
+                  ),
+                );
+              } else {
+                return SwitchListTile(
+                  title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
+                  secondary: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
+                  value: snapshot.data.getBool('dark_theme') ?? false,
+                  onChanged: (dark) => _setDarkTheme(dark, context, snapshot),
+                );
+              }
+            },
+          );
+        case 1:
+          return ThemeSwitcher(
+            clipper: ThemeSwitcherCircleClipper(),
+            builder: (context) {
               return SwitchListTile(
-                title: Text("Thème sombre", style: Theme.of(context).textTheme.bodyText2),
-                secondary: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
-                value: snapshot.data.getBool('dark_theme') ?? false,
-                onChanged: (dark) {
-                  if (dark) {
-                    ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
-                  } else {
-                    ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
-                  }
-                  snapshot.data.setBool('dark_theme', dark);
-                },
+                contentPadding: EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
+                title: Text("Mode sombre automatique", style: Theme.of(context).textTheme.bodyText2),
+                subtitle: Text(
+                  "Cette option activera le mode sombre le soir et le désactivera le matin.",
+                    style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10)
+                ),
+                secondary: Icon(Icons.access_time, color: Theme.of(context).accentColor),
+                value: snapshot.data.getBool('automatic_dark_theme') ?? false,
+                onChanged: (automatic) => _setAutomaticDarkTheme(automatic, context, snapshot),
               );
             },
           );
@@ -80,8 +103,30 @@ class _PreferencesPageState extends State<PreferencesPage> {
           return null;
       }
     } else {
-      return Divider();
+      return Divider(height: 1.0);
     }
+  }
+
+  void _setDarkTheme(bool dark, BuildContext context, AsyncSnapshot<SharedPreferences> snapshot) {
+    if (dark) {
+      ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
+    } else {
+      ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
+    }
+    snapshot.data.setBool('dark_theme', dark);
+  }
+
+  void _setAutomaticDarkTheme(bool automatic, BuildContext context, AsyncSnapshot<SharedPreferences> snapshot) {
+    DateTime now = DateTime.now();
+    if (automatic) {
+      if (now.hour >= 20 || now.hour < 8) ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
+      else ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
+    } else {
+      bool dark = snapshot.data.getBool('dark_theme') ?? false;
+      if (dark) ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
+      else ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
+    }
+    snapshot.data.setBool('automatic_dark_theme', automatic);
   }
 
 }

--- a/lib/pages/preferences_page.dart
+++ b/lib/pages/preferences_page.dart
@@ -77,7 +77,11 @@ class _PreferencesPageState extends State<PreferencesPage> {
                   title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
                   secondary: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
                   value: snapshot.data.getBool('dark_theme') ?? false,
-                  onChanged: (dark) => _setDarkTheme(dark, context, snapshot),
+                  onChanged: (dark) {
+                    if (dark) ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
+                    else ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
+                    snapshot.data.setBool('dark_theme', dark);
+                  }
                 );
               }
             },
@@ -90,12 +94,17 @@ class _PreferencesPageState extends State<PreferencesPage> {
                 contentPadding: EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
                 title: Text("Mode sombre automatique", style: Theme.of(context).textTheme.bodyText2),
                 subtitle: Text(
-                  "Cette option activera le mode sombre le soir et le désactivera le matin.",
+                  "Cette option active automatiquement le mode sombre le soir et le désactive le matin.",
                     style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10)
                 ),
                 secondary: Icon(Icons.access_time, color: Theme.of(context).accentColor),
                 value: snapshot.data.getBool('automatic_dark_theme') ?? false,
-                onChanged: (automatic) => _setAutomaticDarkTheme(automatic, context, snapshot),
+                onChanged: (automatic) {
+                  bool dark = snapshot.data.getBool("dark_theme") ?? false;
+                  ThemeData theme = AppTheme.getThemeFromPreferences(automatic, dark);
+                  ThemeSwitcher.of(context).changeTheme(theme: theme);
+                  snapshot.data.setBool('automatic_dark_theme', automatic);
+                },
               );
             },
           );
@@ -105,28 +114,6 @@ class _PreferencesPageState extends State<PreferencesPage> {
     } else {
       return Divider(height: 1.0);
     }
-  }
-
-  void _setDarkTheme(bool dark, BuildContext context, AsyncSnapshot<SharedPreferences> snapshot) {
-    if (dark) {
-      ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
-    } else {
-      ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
-    }
-    snapshot.data.setBool('dark_theme', dark);
-  }
-
-  void _setAutomaticDarkTheme(bool automatic, BuildContext context, AsyncSnapshot<SharedPreferences> snapshot) {
-    DateTime now = DateTime.now();
-    if (automatic) {
-      if (now.hour >= 20 || now.hour < 8) ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
-      else ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
-    } else {
-      bool dark = snapshot.data.getBool('dark_theme') ?? false;
-      if (dark) ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
-      else ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
-    }
-    snapshot.data.setBool('automatic_dark_theme', automatic);
   }
 
 }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'commons/text_tab_bar.dart';
 
 class AppTheme {
-  static ThemeData theme() {
+  static ThemeData darkTheme() {
     return ThemeData(
       highlightColor: Colors.transparent,
       primarySwatch: Colors.blue,
@@ -71,4 +71,143 @@ class AppTheme {
       ),
     );
   }
+
+  static ThemeData orangeTheme() {
+    return ThemeData(
+      highlightColor: Colors.transparent,
+      primarySwatch: Colors.orange,
+      accentColor: Color(0xff68624d),
+      primaryColor: Color(0xffd9d3be),
+      bottomAppBarColor: Color(0xfff7fbfe),
+      cardTheme: CardTheme(
+        color: Color(0xffcec7ad),
+        margin: EdgeInsets.only(top: 30, left: 20, right: 20, bottom: 0),
+        elevation: 0.0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(18)),
+        ),
+      ),
+      appBarTheme: AppBarTheme(
+        color: Color(0xffcec7ad),
+        textTheme: TextTheme(
+          headline6: TextStyle(
+            color: Color(0xff080401),
+            fontSize: 17.0,
+            fontFamily: "Raleway",
+            fontWeight: FontWeight.bold,
+          ),
+          subtitle2: TextStyle(
+            color: Color(0xff68624d),
+            fontSize: 12.0,
+            fontFamily: "Raleway",
+          ),
+          button: TextStyle(
+            color: Color(0xff080401),
+            fontSize: 17.0,
+            fontFamily: "Raleway",
+          ),
+        ),
+      ),
+      textTheme: TextTheme(
+        headline4: TextStyle(color: Color(0xff080401), fontSize: 20.0, fontFamily: "Raleway", fontWeight: FontWeight.normal),
+        headline5: TextStyle(color: Color(0xff68624d), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
+        headline6: TextStyle(color: Color(0xff68624d), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
+        subtitle1: TextStyle(color: Color(0xff080401), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.bold),
+        subtitle2: TextStyle(color: Color(0xff080401), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.bold),
+        bodyText2: TextStyle(color: Color(0xff080401), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
+        bodyText1: TextStyle(color: Color(0xff68624d), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
+        caption: TextStyle(color: Color(0xff68624d), fontSize: 16, fontFamily: "Raleway"),
+      ),
+      tabBarTheme: TabBarTheme(
+        labelColor: Color(0xff080401),
+        unselectedLabelColor: Color(0xff81775d),
+        labelPadding: const EdgeInsets.fromLTRB(18.0, 0.0, 18.0, 10.0),
+        labelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
+        unselectedLabelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
+        indicatorSize: TabBarIndicatorSize.label,
+        indicator: DashedUnderlineIndicator(
+          width: 30.0,
+          dashSpace: 0,
+          borderSide: BorderSide(width: 6.0, color: Color(0xff81775d)),
+          insets: EdgeInsets.only(
+            left: 30.0,
+            right: 30,
+          ),
+        ),
+      ),
+      buttonBarTheme: ButtonBarThemeData(
+        buttonPadding: EdgeInsets.all(0.0),
+      ),
+    );
+  }
+
+  static ThemeData lightTheme() {
+    return ThemeData(
+      highlightColor: Colors.transparent,
+      primarySwatch: Colors.blue,
+      accentColor: Color(0xff4c4f59),
+      primaryColor: Color(0xffe6e8f2),
+      bottomAppBarColor: Color(0xfff7fbfe),
+      cardTheme: CardTheme(
+        color: Color(0xffcfd3e6),
+        margin: EdgeInsets.only(top: 30, left: 20, right: 20, bottom: 0),
+        elevation: 0.0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(18)),
+        ),
+      ),
+      appBarTheme: AppBarTheme(
+        color: Color(0xff8f96b3),
+        textTheme: TextTheme(
+          headline6: TextStyle(
+            color: Color(0xff080401),
+            fontSize: 17.0,
+            fontFamily: "Raleway",
+            fontWeight: FontWeight.bold,
+          ),
+          subtitle2: TextStyle(
+            color: Color(0xff4c4f59),
+            fontSize: 12.0,
+            fontFamily: "Raleway",
+          ),
+          button: TextStyle(
+            color: Color(0xff080401),
+            fontSize: 17.0,
+            fontFamily: "Raleway",
+          ),
+        ),
+      ),
+      textTheme: TextTheme(
+        headline4: TextStyle(color: Color(0xff080401), fontSize: 20.0, fontFamily: "Raleway", fontWeight: FontWeight.normal),
+        headline5: TextStyle(color: Color(0xff4c4f59), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
+        headline6: TextStyle(color: Color(0xff4c4f59), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
+        subtitle1: TextStyle(color: Color(0xff080401), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.bold),
+        subtitle2: TextStyle(color: Color(0xff080401), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.bold),
+        bodyText2: TextStyle(color: Color(0xff080401), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
+        bodyText1: TextStyle(color: Color(0xff4c4f59), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
+        caption: TextStyle(color: Color(0xff4c4f59), fontSize: 16, fontFamily: "Raleway"),
+      ),
+      tabBarTheme: TabBarTheme(
+        labelColor: Color(0xff080401),
+        unselectedLabelColor: Color(0xff4c4f59),
+        labelPadding: const EdgeInsets.fromLTRB(18.0, 0.0, 18.0, 10.0),
+        labelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
+        unselectedLabelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
+        indicatorSize: TabBarIndicatorSize.label,
+        indicator: DashedUnderlineIndicator(
+          width: 30.0,
+          dashSpace: 0,
+          borderSide: BorderSide(width: 6.0, color: Color(0xff3c404d)),
+          insets: EdgeInsets.only(
+            left: 30.0,
+            right: 30,
+          ),
+        ),
+      ),
+      buttonBarTheme: ButtonBarThemeData(
+        buttonPadding: EdgeInsets.all(0.0),
+      ),
+    );
+  }
+
 }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -72,75 +72,6 @@ class AppTheme {
     );
   }
 
-  static ThemeData orangeTheme() {
-    return ThemeData(
-      highlightColor: Colors.transparent,
-      primarySwatch: Colors.orange,
-      accentColor: Color(0xff68624d),
-      primaryColor: Color(0xffd9d3be),
-      bottomAppBarColor: Color(0xfff7fbfe),
-      cardTheme: CardTheme(
-        color: Color(0xffcec7ad),
-        margin: EdgeInsets.only(top: 30, left: 20, right: 20, bottom: 0),
-        elevation: 0.0,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(18)),
-        ),
-      ),
-      appBarTheme: AppBarTheme(
-        color: Color(0xffcec7ad),
-        textTheme: TextTheme(
-          headline6: TextStyle(
-            color: Color(0xff080401),
-            fontSize: 17.0,
-            fontFamily: "Raleway",
-            fontWeight: FontWeight.bold,
-          ),
-          subtitle2: TextStyle(
-            color: Color(0xff68624d),
-            fontSize: 12.0,
-            fontFamily: "Raleway",
-          ),
-          button: TextStyle(
-            color: Color(0xff080401),
-            fontSize: 17.0,
-            fontFamily: "Raleway",
-          ),
-        ),
-      ),
-      textTheme: TextTheme(
-        headline4: TextStyle(color: Color(0xff080401), fontSize: 20.0, fontFamily: "Raleway", fontWeight: FontWeight.normal),
-        headline5: TextStyle(color: Color(0xff68624d), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
-        headline6: TextStyle(color: Color(0xff68624d), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
-        subtitle1: TextStyle(color: Color(0xff080401), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.bold),
-        subtitle2: TextStyle(color: Color(0xff080401), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.bold),
-        bodyText2: TextStyle(color: Color(0xff080401), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
-        bodyText1: TextStyle(color: Color(0xff68624d), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
-        caption: TextStyle(color: Color(0xff68624d), fontSize: 16, fontFamily: "Raleway"),
-      ),
-      tabBarTheme: TabBarTheme(
-        labelColor: Color(0xff080401),
-        unselectedLabelColor: Color(0xff81775d),
-        labelPadding: const EdgeInsets.fromLTRB(18.0, 0.0, 18.0, 10.0),
-        labelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
-        unselectedLabelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
-        indicatorSize: TabBarIndicatorSize.label,
-        indicator: DashedUnderlineIndicator(
-          width: 30.0,
-          dashSpace: 0,
-          borderSide: BorderSide(width: 6.0, color: Color(0xff81775d)),
-          insets: EdgeInsets.only(
-            left: 30.0,
-            right: 30,
-          ),
-        ),
-      ),
-      buttonBarTheme: ButtonBarThemeData(
-        buttonPadding: EdgeInsets.all(0.0),
-      ),
-    );
-  }
-
   static ThemeData lightTheme() {
     return ThemeData(
       highlightColor: Colors.transparent,
@@ -208,6 +139,17 @@ class AppTheme {
         buttonPadding: EdgeInsets.all(0.0),
       ),
     );
+  }
+
+  static ThemeData getThemeFromPreferences(bool automatic, bool dark) {
+    DateTime now = DateTime.now();
+    if (automatic) {
+      if (now.hour >= 20 || now.hour < 8) return AppTheme.darkTheme();
+      else return AppTheme.lightTheme();
+    } else {
+      if (dark) return AppTheme.darkTheme();
+      else return AppTheme.lightTheme();
+    }
   }
 
 }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -157,7 +157,7 @@ class AppTheme {
         ),
       ),
       appBarTheme: AppBarTheme(
-        color: Color(0xff8f96b3),
+        color: Color(0xffcfd3e6),
         textTheme: TextTheme(
           headline6: TextStyle(
             color: Color(0xff080401),

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -146,10 +146,10 @@ class AppTheme {
       highlightColor: Colors.transparent,
       primarySwatch: Colors.blue,
       accentColor: Color(0xff4c4f59),
-      primaryColor: Color(0xffe6e8f2),
-      bottomAppBarColor: Color(0xfff7fbfe),
+      primaryColor: Color(0xfff3f5ff),
+      bottomAppBarColor: Color(0xffe2e5f3),
       cardTheme: CardTheme(
-        color: Color(0xffcfd3e6),
+        color: Color(0xffeceef8),
         margin: EdgeInsets.only(top: 30, left: 20, right: 20, bottom: 0),
         elevation: 0.0,
         shape: RoundedRectangleBorder(
@@ -157,7 +157,7 @@ class AppTheme {
         ),
       ),
       appBarTheme: AppBarTheme(
-        color: Color(0xffcfd3e6),
+        color: Color(0xffe2e5f3),
         textTheme: TextTheme(
           headline6: TextStyle(
             color: Color(0xff080401),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -528,7 +528,7 @@ packages:
     source: hosted
     version: "0.23.1"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -15,6 +15,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.39.8"
+  animated_theme_switcher:
+    dependency: "direct main"
+    description:
+      name: animated_theme_switcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.6"
   archive:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   radial_button: ^1.0.0
   flushbar: ^1.10.4
   simple_gravatar: ^1.0.5
+  animated_theme_switcher: ^1.0.5
   
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   flushbar: ^1.10.4
   simple_gravatar: ^1.0.5
   animated_theme_switcher: ^1.0.5
+  shared_preferences: ^0.5.7+3
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Close #47 
I added a switch button to permit the user to switch between a light and a dark theme on the dashboard. There is also a "circle clipper" animation (thanks to a package I found) to have a smooth switching.

<img src="https://user-images.githubusercontent.com/67117547/86511322-4aa3a880-bdf8-11ea-97fb-6e125b1ff000.jpg" height=400>
<img src="https://user-images.githubusercontent.com/67117547/86511321-48d9e500-bdf8-11ea-8178-ce1c1e1adc31.jpg" height=400>

