### PR TITLE
Selection of favorite teams and sort on the dashboard

### DIFF
--- a/lib/commons/favorite/favorite_bloc.dart
+++ b/lib/commons/favorite/favorite_bloc.dart
@@ -54,33 +54,16 @@ class FavoriteBloc extends Bloc<FavoriteEvent, FavoriteState> {
   Stream<FavoriteState> mapEventToState(FavoriteEvent event) async* {
     if (event is FavoriteUpdateEvent) {
       yield FavoriteUpdating();
-      var firstClubFavorite = await _isFirstClubFavorite(event);
-      repository.updateFavorite(favoriteId, favoriteType, event.favorite);
-      if (firstClubFavorite) {
-        _updateAllTeamAsFavorite(true);
-      } else if (!event.favorite) {
-        _updateAllTeamAsFavorite(false);
-      }
+      await repository.updateFavorite(favoriteId, favoriteType, event.favorite);
       yield FavoriteUpdated(event.favorite);
     }
     if (event is FavoriteLoadEvent) {
       yield FavoriteUpdating();
-      var favorite = await repository.isClubFavorite(favoriteId);
+      var favorite;
+      if (favoriteType == FavoriteType.Club) favorite = await repository.isClubFavorite(favoriteId);
+      else favorite = await repository.isTeamFavorite(favoriteId);
       yield FavoriteLoaded(favorite);
     }
-  }
-  
-  Future<bool> _isFirstClubFavorite(FavoriteUpdateEvent event) async {
-    if (favoriteType == FavoriteType.Club && event.favorite) {
-      var currentFavoriteClubs = await repository.loadFavoriteClubs();
-      return currentFavoriteClubs.isEmpty;
-    }
-    return false;
-  }
-  
-  Future<void> _updateAllTeamAsFavorite(bool fav) async {
-    var teams = await repository.loadClubTeams(favoriteId);
-    teams.forEach((team) => repository.updateFavorite(team.code, FavoriteType.Team, fav));
   }
   
 }

--- a/lib/commons/favorite/favorite_icon.dart
+++ b/lib/commons/favorite/favorite_icon.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:like_button/like_button.dart';
 import 'package:v34/commons/favorite/favorite.dart';
 import 'package:v34/repositories/repository.dart';
+import 'package:v34/utils/extensions.dart';
 
 import 'favorite_bloc.dart';
 
@@ -68,7 +69,7 @@ class _FavoriteIconState extends State<FavoriteIcon> with SingleTickerProviderSt
             likeBuilder: (bool isLiked) {
               return Icon(
                 isLiked ? Icons.star : Icons.star_border,
-                color: isLiked ? Colors.yellow : Theme.of(context).textTheme.bodyText1.color,
+                color: isLiked ? Colors.orangeAccent : Theme.of(context).textTheme.bodyText1.color,
                 size: 26,
               );
             },

--- a/lib/pages/club-details/blocs/club_teams.bloc.dart
+++ b/lib/pages/club-details/blocs/club_teams.bloc.dart
@@ -32,18 +32,8 @@ class ClubTeamsLoadEvent extends ClubTeamsEvent {
 class ClubTeamsBloc extends Bloc<ClubTeamsEvent, ClubTeamsState> {
 
   final Repository repository;
-  final FavoriteBloc favoriteBloc;
-  List<String> _favoriteTeams = [];
 
-  ClubTeamsBloc({@required this.repository, this.favoriteBloc}) {
-    if (favoriteBloc != null) {
-      favoriteBloc.listen((state) {
-        if (state is FavoriteLoadedState) {
-          _favoriteTeams.addAll(state.teamCodes);
-        }
-      });
-    }
-  }
+  ClubTeamsBloc({@required this.repository});
 
   @override
   ClubTeamsState get initialState => ClubTeamsUninitialized();
@@ -53,9 +43,10 @@ class ClubTeamsBloc extends Bloc<ClubTeamsEvent, ClubTeamsState> {
     if (event is ClubTeamsLoadEvent) {
       yield ClubTeamsLoading();
       var teams  = await repository.loadClubTeams(event.clubCode);
-      if (_favoriteTeams.isNotEmpty) {
+      var favTeams = await repository.loadFavoriteTeamCodes();
+      if (favTeams.isNotEmpty) {
         teams.forEach((team) {
-          if (_favoriteTeams.contains(team.code)) team.favorite = true;
+          if (favTeams.contains(team.code)) team.favorite = true;
         });
       }
       teams.sort((team1, team2) {

--- a/lib/pages/club-details/blocs/club_teams.bloc.dart
+++ b/lib/pages/club-details/blocs/club_teams.bloc.dart
@@ -1,12 +1,11 @@
-
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:v34/models/team.dart';
+import 'package:v34/pages/dashboard/blocs/favorite_bloc.dart';
 import 'package:v34/repositories/repository.dart';
 
-//---- STATE
-@immutable
+// ----- STATES -----
+
 abstract class ClubTeamsState {}
 
 class ClubTeamsUninitialized extends ClubTeamsState {}
@@ -19,8 +18,8 @@ class ClubTeamsLoaded extends ClubTeamsState {
 }
 
 
-//---- EVENT
-@immutable
+// ----- EVENTS -----
+
 abstract class ClubTeamsEvent {}
 
 class ClubTeamsLoadEvent extends ClubTeamsEvent {
@@ -28,12 +27,23 @@ class ClubTeamsLoadEvent extends ClubTeamsEvent {
   ClubTeamsLoadEvent({@required this.clubCode});
 }
 
-//---- BLOC
+// ----- BLOC -----
+
 class ClubTeamsBloc extends Bloc<ClubTeamsEvent, ClubTeamsState> {
 
   final Repository repository;
+  final FavoriteBloc favoriteBloc;
+  List<String> _favoriteTeams = [];
 
-  ClubTeamsBloc({@required this.repository});
+  ClubTeamsBloc({@required this.repository, this.favoriteBloc}) {
+    if (favoriteBloc != null) {
+      favoriteBloc.listen((state) {
+        if (state is FavoriteLoadedState) {
+          _favoriteTeams.addAll(state.teamCodes);
+        }
+      });
+    }
+  }
 
   @override
   ClubTeamsState get initialState => ClubTeamsUninitialized();
@@ -43,10 +53,17 @@ class ClubTeamsBloc extends Bloc<ClubTeamsEvent, ClubTeamsState> {
     if (event is ClubTeamsLoadEvent) {
       yield ClubTeamsLoading();
       var teams  = await repository.loadClubTeams(event.clubCode);
-      final seen = Set<String>();
-      teams.sort((team1, team2) => team1.name.compareTo(team2.name));
-      var uniqueTeams = teams.where((team) => seen.add(team.name)).toList();
-      yield ClubTeamsLoaded(teams: uniqueTeams);
+      if (_favoriteTeams.isNotEmpty) {
+        teams.forEach((team) {
+          if (_favoriteTeams.contains(team.code)) team.favorite = true;
+        });
+      }
+      teams.sort((team1, team2) {
+        if (team1.favorite && !team2.favorite) return -1;
+        if (!team1.favorite && team2.favorite) return 1;
+        else return team1.name.compareTo(team2.name);
+      });
+      yield ClubTeamsLoaded(teams: teams);
     }
   }
 

--- a/lib/pages/club-details/teams/club_team.dart
+++ b/lib/pages/club-details/teams/club_team.dart
@@ -1,9 +1,9 @@
-import 'dart:math' as math;
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:v34/commons/cards/titled_card.dart';
+import 'package:v34/commons/favorite/favorite.dart';
+import 'package:v34/commons/favorite/favorite_icon.dart';
 import 'package:v34/commons/graphs/arc.dart';
 import 'package:v34/commons/graphs/line_graph.dart';
 import 'package:v34/commons/loading.dart';
@@ -45,6 +45,11 @@ class _ClubTeamState extends State<ClubTeam> {
       title: widget.team.name,
       bodyPadding: EdgeInsets.only(top: 18, bottom: 18, right: 8, left: 16),
       onTap: () => Router.push(context: context, builder: (_) => TeamDetailPage(team: widget.team)),
+      buttonBar: ButtonBar(
+        children: <Widget>[
+          FavoriteIcon(widget.team.code, FavoriteType.Team, false, padding: EdgeInsets.zero, reloadFavoriteWhenUpdate: true,),
+        ],
+      ),
       body: BlocBuilder(
         bloc: _teamBloc,
         builder: (context, state) {

--- a/lib/pages/club-details/teams/club_teams.dart
+++ b/lib/pages/club-details/teams/club_teams.dart
@@ -21,7 +21,7 @@ class _ClubTeamsState extends State<ClubTeams> {
   @override
   void initState() {
     super.initState();
-    _clubTeamsBloc = ClubTeamsBloc(repository: RepositoryProvider.of<Repository>(context))..add(ClubTeamsLoadEvent(clubCode: widget.club.code));
+    _clubTeamsBloc = ClubTeamsBloc(repository: RepositoryProvider.of<Repository>(context))..add(ClubTeamsLoadEvent(widget.club.code));
   }
 
   @override

--- a/lib/pages/club/club_page.dart
+++ b/lib/pages/club/club_page.dart
@@ -38,10 +38,16 @@ class _ClubPageState extends State<ClubPage> with SingleTickerProviderStateMixin
       _loading = true;
     });
     _repository.loadAllClubs().then((clubs) {
-      setState(() {
-        _loading = false;
-        clubs.sort((c1, c2) => c1.shortName.toUpperCase().compareTo(c2.shortName.toUpperCase()));
-        _clubs = clubs;
+      _repository.loadFavoriteClubCodes().then((favorites) {
+        setState(() {
+          _loading = false;
+          clubs.sort((c1, c2) {
+            if (favorites.contains(c1.code) && !favorites.contains(c2.code)) return -1;
+            if (!favorites.contains(c1.code) && favorites.contains(c2.code)) return 1;
+            return c1.shortName.toUpperCase().compareTo(c2.shortName.toUpperCase());
+          });
+          _clubs = clubs;
+        });
       });
     });
   }

--- a/lib/pages/dashboard/blocs/favorite_bloc.dart
+++ b/lib/pages/dashboard/blocs/favorite_bloc.dart
@@ -1,5 +1,3 @@
-
-
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -9,29 +7,25 @@ import 'package:v34/repositories/repository.dart';
 //--- States
 @immutable
 abstract class FavoriteState extends Equatable {
+  @override
+  List<Object> get props => [];
+}
 
+class FavoriteUninitializedState extends FavoriteState {}
+
+class FavoriteLoadingState extends FavoriteState {}
+
+class FavoriteLoadedState extends FavoriteState {
   final List<String> teamCodes;
   final List<Club> clubs;
 
-  const FavoriteState(this.teamCodes, this.clubs) : assert(teamCodes != null), assert(clubs != null);
+  FavoriteLoadedState(this.teamCodes, this.clubs) : assert(teamCodes != null), assert(clubs != null);
 
   @override
   List<Object> get props => [teamCodes, clubs];
 
   @override
   String toString() => "FavoriteState(teams: $teamCodes, clubs: $clubs)";
-}
-
-class FavoriteUninitializedState extends FavoriteState {
-  const FavoriteUninitializedState(List<String> teamCodes, List<Club> clubs) : super(teamCodes, clubs);
-}
-
-class FavoriteLoadingState extends FavoriteState {
-  const FavoriteLoadingState(List<String> teamCodes, List<Club> clubs) : super(teamCodes, clubs);
-}
-
-class FavoriteLoadedState extends FavoriteState {
-  const FavoriteLoadedState(List<String> teamCodes, List<Club> clubs) : super(teamCodes, clubs);
 }
 
 
@@ -51,7 +45,7 @@ class FavoriteLoadEvent extends FavoriteEvent {}
 
 class FavoriteBloc extends Bloc<FavoriteEvent, FavoriteState> {
   @override
-  FavoriteState get initialState => FavoriteUninitializedState([], []);
+  FavoriteState get initialState => FavoriteUninitializedState();
 
   final Repository repository;
 
@@ -60,9 +54,10 @@ class FavoriteBloc extends Bloc<FavoriteEvent, FavoriteState> {
   @override
   Stream<FavoriteState> mapEventToState(FavoriteEvent event) async* {
     if (event is FavoriteLoadEvent) {
-      yield FavoriteLoadingState([], []);
+      yield FavoriteLoadingState();
       var favClubs = await repository.loadFavoriteClubs();
-      yield FavoriteLoadedState([], favClubs);
+      var favTeamsCodes = await repository.loadFavoriteTeamCodes();
+      yield FavoriteLoadedState(favTeamsCodes, favClubs);
     }
   }
 

--- a/lib/pages/dashboard/dashboard_club_teams.dart
+++ b/lib/pages/dashboard/dashboard_club_teams.dart
@@ -49,14 +49,18 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
           _pageController.jumpTo(0);
       }
     });
-    _clubTeamsBloc.add(ClubTeamsLoadEvent(clubCode: widget.clubCode));
+    _loadFavoriteTeams();
     super.initState();
   }
 
   @override
   void didUpdateWidget(DashboardClubTeams oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _clubTeamsBloc.add(ClubTeamsLoadEvent(clubCode: widget.clubCode));
+    _loadFavoriteTeams();
+  }
+
+  void _loadFavoriteTeams() {
+    _clubTeamsBloc.add(ClubFavoriteTeamsLoadEvent(widget.clubCode));
   }
 
   Widget _buildTeamCategory(ClubTeamsLoaded state) {

--- a/lib/pages/dashboard/dashboard_club_teams.dart
+++ b/lib/pages/dashboard/dashboard_club_teams.dart
@@ -42,7 +42,6 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
       });
     _clubTeamsBloc = ClubTeamsBloc(
       repository: RepositoryProvider.of<Repository>(context),
-      favoriteBloc: BlocProvider.of<FavoriteBloc>(context)
     );
     _clubTeamsBloc.listen((state) {
       if (state is ClubTeamsLoaded && _pageController.hasClients) {
@@ -51,11 +50,6 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
       }
     });
     _clubTeamsBloc.add(ClubTeamsLoadEvent(clubCode: widget.clubCode));
-    BlocProvider.of<FavoriteBloc>(context).listen((state) {
-      if (state is FavoriteLoadedState) {
-        _clubTeamsBloc.add(ClubTeamsLoadEvent(clubCode: widget.clubCode));
-      }
-    });
     super.initState();
   }
 

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -34,7 +34,8 @@ class _DashboardPageState extends State<DashboardPage> {
   @override
   void initState() {
     super.initState();
-    _favoriteBloc = FavoriteBloc(repository: RepositoryProvider.of<Repository>(context))..add(FavoriteLoadEvent());
+    _favoriteBloc = FavoriteBloc(repository: RepositoryProvider.of<Repository>(context))
+      ..add(FavoriteLoadEvent());
     _favoriteBloc.skip(1).listen((state) {
       if (state is FavoriteLoadedState) {
         if (state.clubs.length > 0) {
@@ -47,9 +48,11 @@ class _DashboardPageState extends State<DashboardPage> {
     _agendaBloc = AgendaBloc(repository: RepositoryProvider.of<Repository>(context))..add(AgendaLoadWeek(week: 0));
     _pageController = PageController(initialPage: 0)
       ..addListener(() {
-        setState(() {
-          currentFavoriteClubPage = _pageController.page;
-        });
+        if (currentFavoriteClubPage != _pageController.page) {
+          setState(() {
+            currentFavoriteClubPage = _pageController.page;
+          });
+        }
       });
   }
 
@@ -80,10 +83,7 @@ class _DashboardPageState extends State<DashboardPage> {
       child: FavoriteClubCard(
         state.clubs[index],
         () => Router.push(context: context, builder: (_) => ClubDetailPage(state.clubs[index])).then(
-          (_) {
-            _favoriteBloc.add(FavoriteLoadEvent());
-            setState(() {});
-          },
+          (_) => _updateClubTeams(state.clubs[index].code),
         ),
       ),
     );
@@ -139,18 +139,14 @@ class _DashboardPageState extends State<DashboardPage> {
                 ],
               )
             : Container(
-                constraints: BoxConstraints(minHeight: 100),
-                child: Center(child: Loading()),
+                constraints: BoxConstraints(minHeight: 0),
               );
       case 2:
         return Paragraph(
           title: state.teamCodes.length > 1 ? "Vos équipes" : "Vos équipes",
         );
       case 3:
-        return BlocProvider(
-          create: (context) => _favoriteBloc,
-          child: DashboardClubTeams(clubCode: _currentClubCode),
-        );
+        return DashboardClubTeams(clubCode: _currentClubCode);
       case 4:
         return Paragraph(
           title: "Votre agenda",

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -73,10 +73,6 @@ class _DashboardPageState extends State<DashboardPage> {
         }));
   }
 
-  void _gotoPreferencesPage() {
-    Navigator.of(context).push(MaterialPageRoute<void>(builder: (context) => PreferencesPage()));
-  }
-
   Widget _buildFavoriteClubCard(FavoriteLoadedState state, int index, double distance) {
     var absDistance = distance.abs() > 1 ? 1 : distance.abs();
     return Transform.scale(
@@ -124,7 +120,9 @@ class _DashboardPageState extends State<DashboardPage> {
                       controller: _pageController,
                       onPageChanged: (pageIndex) => _updateClubTeams(state.clubs[pageIndex].code),
                       itemBuilder: (context, index) => Padding(
-                          padding: const EdgeInsets.only(left: 8.0, right: 0), child: _buildFavoriteClubCard(state, index, currentFavoriteClubPage - index)),
+                        padding: const EdgeInsets.only(left: 8.0, right: 0),
+                        child: _buildFavoriteClubCard(state, index, currentFavoriteClubPage - index),
+                      ),
                     ),
                   ),
                   if (state.clubs.length > 1)

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -5,6 +5,7 @@ import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:v34/commons/loading.dart';
 import 'package:v34/commons/page/main_page.dart';
 import 'package:v34/commons/router.dart';
+import 'package:v34/models/club.dart';
 import 'package:v34/pages/club-details/club_detail_page.dart';
 import 'package:v34/pages/dashboard/blocs/agenda_bloc.dart';
 import 'package:v34/pages/dashboard/blocs/favorite_bloc.dart';
@@ -28,7 +29,7 @@ class _DashboardPageState extends State<DashboardPage> {
   FavoriteBloc _favoriteBloc;
   AgendaBloc _agendaBloc;
   PageController _pageController;
-  String _currentClubCode;
+  Club _currentClub;
   double currentFavoriteClubPage = 0;
 
   @override
@@ -40,7 +41,7 @@ class _DashboardPageState extends State<DashboardPage> {
       if (state is FavoriteLoadedState) {
         if (state.clubs.length > 0) {
           setState(() {
-            _currentClubCode = state.clubs[0].code;
+            _currentClub = state.clubs[0];
           });
         }
       }
@@ -83,7 +84,7 @@ class _DashboardPageState extends State<DashboardPage> {
       child: FavoriteClubCard(
         state.clubs[index],
         () => Router.push(context: context, builder: (_) => ClubDetailPage(state.clubs[index])).then(
-          (_) => _updateClubTeams(state.clubs[index].code),
+          (_) => _selectCurrentClub(state.clubs[index]),
         ),
       ),
     );
@@ -118,7 +119,7 @@ class _DashboardPageState extends State<DashboardPage> {
                       physics: BouncingScrollPhysics(),
                       itemCount: state.clubs.length,
                       controller: _pageController,
-                      onPageChanged: (pageIndex) => _updateClubTeams(state.clubs[pageIndex].code),
+                      onPageChanged: (pageIndex) => _selectCurrentClub(state.clubs[pageIndex]),
                       itemBuilder: (context, index) => Padding(
                         padding: const EdgeInsets.only(left: 8.0, right: 0),
                         child: _buildFavoriteClubCard(state, index, currentFavoriteClubPage - index),
@@ -142,11 +143,9 @@ class _DashboardPageState extends State<DashboardPage> {
                 constraints: BoxConstraints(minHeight: 0),
               );
       case 2:
-        return Paragraph(
-          title: state.teamCodes.length > 1 ? "Vos équipes" : "Vos équipes",
-        );
+        return Paragraph(title: "Vos équipes");
       case 3:
-        return DashboardClubTeams(clubCode: _currentClubCode);
+        return DashboardClubTeams(club: _currentClub, onTeamFavoriteChange: (_) => _selectCurrentClub(_currentClub));
       case 4:
         return Paragraph(
           title: "Votre agenda",
@@ -184,9 +183,9 @@ class _DashboardPageState extends State<DashboardPage> {
     }
   }
 
-  _updateClubTeams(String clubCode) {
+  _selectCurrentClub(Club club) {
     setState(() {
-      _currentClubCode = clubCode;
+      _currentClub = club;
     });
   }
 }

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -77,7 +77,7 @@ class _DashboardPageState extends State<DashboardPage> {
     Navigator.of(context).push(MaterialPageRoute<void>(builder: (context) => PreferencesPage()));
   }
 
-  Widget _buildFavoriteClubCard(FavoriteState state, int index, double distance) {
+  Widget _buildFavoriteClubCard(FavoriteLoadedState state, int index, double distance) {
     var absDistance = distance.abs() > 1 ? 1 : distance.abs();
     return Transform.scale(
       scale: 1.0 - (absDistance > 0.15 ? 0.15 : absDistance),
@@ -103,7 +103,7 @@ class _DashboardPageState extends State<DashboardPage> {
     }
   }
 
-  Widget _buildDashboardItem(int index, FavoriteState state) {
+  Widget _buildDashboardItem(int index, FavoriteLoadedState state) {
     switch (index) {
       case 0:
         return Paragraph(
@@ -146,7 +146,10 @@ class _DashboardPageState extends State<DashboardPage> {
           title: state.teamCodes.length > 1 ? "Vos équipes" : "Vos équipes",
         );
       case 3:
-        return DashboardClubTeams(clubCode: _currentClubCode);
+        return BlocProvider(
+          create: (context) => _favoriteBloc,
+          child: DashboardClubTeams(clubCode: _currentClubCode),
+        );
       case 4:
         return Paragraph(
           title: "Votre agenda",

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -84,7 +84,10 @@ class _DashboardPageState extends State<DashboardPage> {
       child: FavoriteClubCard(
         state.clubs[index],
         () => Router.push(context: context, builder: (_) => ClubDetailPage(state.clubs[index])).then(
-          (_) => _favoriteBloc.add(FavoriteLoadEvent()),
+          (_) {
+            _favoriteBloc.add(FavoriteLoadEvent());
+            setState(() {});
+          },
         ),
       ),
     );

--- a/lib/pages/dashboard/fav_club_card.dart
+++ b/lib/pages/dashboard/fav_club_card.dart
@@ -18,7 +18,7 @@ class FavoriteClubCard extends StatefulWidget {
   _FavoriteClubCardState createState() => _FavoriteClubCardState();
 }
 
-class _FavoriteClubCardState extends State<FavoriteClubCard> with AutomaticKeepAliveClientMixin {
+class _FavoriteClubCardState extends State<FavoriteClubCard> {
   ClubStatsBloc _clubStatsBloc;
   List<CircularStackEntry> _data;
 
@@ -66,7 +66,6 @@ class _FavoriteClubCardState extends State<FavoriteClubCard> with AutomaticKeepA
 
   @override
   Widget build(BuildContext context) {
-    super.build(context);
     return RoundedTitledCard(
       title: widget.club.shortName,
       heroTag: "hero-logo-${widget.club.code}",
@@ -164,6 +163,4 @@ class _FavoriteClubCardState extends State<FavoriteClubCard> with AutomaticKeepA
     );
   }
 
-  @override
-  bool get wantKeepAlive => true;
 }

--- a/lib/pages/dashboard/team_card.dart
+++ b/lib/pages/dashboard/team_card.dart
@@ -87,6 +87,14 @@ class _TeamCardState extends State<TeamCard> {
     }
   }
 
+  Widget _buildStar() {
+    return Positioned(
+      top: 38,
+      right: 35,
+      child: Icon(Icons.star, color: Theme.of(context).accentColor),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     var absDistance = widget.distance.abs() > 1 ? 1 : widget.distance.abs();
@@ -96,14 +104,19 @@ class _TeamCardState extends State<TeamCard> {
       builder: (context, state) {
         return Transform.scale(
           scale: 1.0 - (absDistance > 0.15 ? 0.15 : absDistance),
-          child: TitledCard(
-            title: widget.team.name,
-            bodyPadding: EdgeInsets.zero,
-            body: Container(
-              height: cardBodyHeight,
-              child: Row(children: _getPodiumWidget(state)),
-            ),
-            onTap: widget.onTap,
+          child: Stack(
+            children: <Widget>[
+              TitledCard(
+                title: widget.team.name,
+                bodyPadding: EdgeInsets.zero,
+                body: Container(
+                  height: cardBodyHeight,
+                  child: Row(children: _getPodiumWidget(state)),
+                ),
+                onTap: widget.onTap,
+              ),
+              if (widget.team.favorite) _buildStar(),
+            ],
           ),
         );
       },

--- a/lib/pages/dashboard/team_card.dart
+++ b/lib/pages/dashboard/team_card.dart
@@ -87,14 +87,6 @@ class _TeamCardState extends State<TeamCard> {
     }
   }
 
-  Widget _buildStar() {
-    return Positioned(
-      top: 38,
-      right: 35,
-      child: Icon(Icons.star, color: Theme.of(context).accentColor),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     var absDistance = widget.distance.abs() > 1 ? 1 : widget.distance.abs();
@@ -104,19 +96,14 @@ class _TeamCardState extends State<TeamCard> {
       builder: (context, state) {
         return Transform.scale(
           scale: 1.0 - (absDistance > 0.15 ? 0.15 : absDistance),
-          child: Stack(
-            children: <Widget>[
-              TitledCard(
-                title: widget.team.name,
-                bodyPadding: EdgeInsets.zero,
-                body: Container(
-                  height: cardBodyHeight,
-                  child: Row(children: _getPodiumWidget(state)),
-                ),
-                onTap: widget.onTap,
-              ),
-              if (widget.team.favorite) _buildStar(),
-            ],
+          child: TitledCard(
+            title: widget.team.name,
+            bodyPadding: EdgeInsets.zero,
+            body: Container(
+              height: cardBodyHeight,
+              child: Row(children: _getPodiumWidget(state)),
+            ),
+            onTap: widget.onTap,
           ),
         );
       },

--- a/lib/repositories/repository.dart
+++ b/lib/repositories/repository.dart
@@ -52,6 +52,11 @@ class Repository {
     return _favoriteProvider.loadFavoriteTeams();
   }
 
+  /// Load all favorite club codes
+  Future<List<String>> loadFavoriteClubCodes() async {
+    return _favoriteProvider.loadFavoriteClubs();
+  }
+
   //------ TEAM -------
 
   /// Load a club's teams

--- a/lib/repositories/repository.dart
+++ b/lib/repositories/repository.dart
@@ -116,6 +116,11 @@ class Repository {
     return _favoriteProvider.loadFavoriteClubs().then((clubs) => clubs.contains(code));
   }
 
+  /// Return if a team is in favorites
+  Future<bool> isTeamFavorite(String code) async {
+    return _favoriteProvider.loadFavoriteTeams().then((teams) => teams.contains(code));
+  }
+
   /// Load the club statistics by team
   Future<List<TeamStat>> loadClubStats(String clubCode) async {
     return _clubProvider.loadClubStats(clubCode);

--- a/lib/repositories/repository.dart
+++ b/lib/repositories/repository.dart
@@ -47,6 +47,10 @@ class Repository {
     }).toList();
   }
 
+  /// Load all favorite team codes
+  Future<List<String>> loadFavoriteTeamCodes() async {
+    return _favoriteProvider.loadFavoriteTeams();
+  }
 
   //------ TEAM -------
 

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -40,6 +40,7 @@ class AppTheme {
         ),
       ),
       textTheme: TextTheme(
+        button: TextStyle(color: Color(0xFFF7FBFE), fontSize: 14.0, fontFamily: "Raleway", fontWeight: FontWeight.normal),
         headline4: TextStyle(color: Color(0xFFF7FBFE), fontSize: 20.0, fontFamily: "Raleway", fontWeight: FontWeight.normal),
         headline5: TextStyle(color: Color(0xFF979DB2), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
         headline6: TextStyle(color: Color(0xFF979DB2), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
@@ -69,87 +70,110 @@ class AppTheme {
       buttonBarTheme: ButtonBarThemeData(
         buttonPadding: EdgeInsets.all(0.0),
       ),
+      buttonTheme: ButtonThemeData(
+          buttonColor: Color(0xFF373E5D),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(18.0),
+            side: BorderSide(
+              color: Colors.transparent,
+            ),
+          ),
+          textTheme: ButtonTextTheme.accent),
     );
   }
 
   static ThemeData lightTheme() {
     return ThemeData(
-      highlightColor: Colors.transparent,
-      primarySwatch: Colors.blue,
-      accentColor: Color(0xff4c4f59),
-      primaryColor: Color(0xfff3f5ff),
-      bottomAppBarColor: Color(0xffe2e5f3),
-      cardTheme: CardTheme(
-        color: Color(0xffeceef8),
-        margin: EdgeInsets.only(top: 30, left: 20, right: 20, bottom: 0),
-        elevation: 0.0,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(18)),
+        highlightColor: Colors.transparent,
+        primarySwatch: Colors.blue,
+        accentColor: Color(0xff4c4f59),
+        primaryColor: Color(0xfff3f5ff),
+        bottomAppBarColor: Color(0xffe2e5f3),
+        cardTheme: CardTheme(
+          color: Color(0xffeceef8),
+          margin: EdgeInsets.only(top: 30, left: 20, right: 20, bottom: 0),
+          elevation: 0.0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(18)),
+          ),
         ),
-      ),
-      appBarTheme: AppBarTheme(
-        color: Color(0xffe2e5f3),
+        appBarTheme: AppBarTheme(
+          color: Color(0xffe2e5f3),
+          textTheme: TextTheme(
+            headline6: TextStyle(
+              color: Color(0xff080401),
+              fontSize: 22.0,
+              fontFamily: "Raleway",
+              fontWeight: FontWeight.w600,
+            ),
+            subtitle2: TextStyle(
+              color: Color(0xff4c4f59),
+              fontSize: 12.0,
+              fontFamily: "Raleway",
+            ),
+            button: TextStyle(
+              color: Color(0xff080401),
+              fontSize: 17.0,
+              fontFamily: "Raleway",
+            ),
+          ),
+        ),
         textTheme: TextTheme(
-          headline6: TextStyle(
-            color: Color(0xff080401),
-            fontSize: 22.0,
-            fontFamily: "Raleway",
-            fontWeight: FontWeight.w600,
-          ),
-          subtitle2: TextStyle(
-            color: Color(0xff4c4f59),
-            fontSize: 12.0,
-            fontFamily: "Raleway",
-          ),
-          button: TextStyle(
-            color: Color(0xff080401),
-            fontSize: 17.0,
-            fontFamily: "Raleway",
+          button: TextStyle(color: Color(0xff020202), fontSize: 14.0, fontFamily: "Raleway", fontWeight: FontWeight.normal),
+          headline4: TextStyle(color: Color(0xff020202), fontSize: 20.0, fontFamily: "Raleway", fontWeight: FontWeight.normal),
+          headline5: TextStyle(color: Color(0xff8c8f99), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
+          headline6: TextStyle(color: Color(0xff8c8f99), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
+          subtitle1: TextStyle(color: Color(0xff020202), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.bold),
+          subtitle2: TextStyle(color: Color(0xff020202), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.bold),
+          bodyText2: TextStyle(color: Color(0xff020202), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
+          bodyText1: TextStyle(color: Color(0xff8c8f99), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
+          caption: TextStyle(color: Color(0xff8c8f99), fontSize: 16, fontFamily: "Raleway"),
+        ),
+        tabBarTheme: TabBarTheme(
+          labelColor: Color(0xff080401),
+          unselectedLabelColor: Color(0xff4c4f59),
+          labelPadding: const EdgeInsets.fromLTRB(18.0, 0.0, 18.0, 10.0),
+          labelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
+          unselectedLabelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
+          indicatorSize: TabBarIndicatorSize.label,
+          indicator: DashedUnderlineIndicator(
+            width: 30.0,
+            dashSpace: 0,
+            borderSide: BorderSide(width: 6.0, color: Color(0xff3c404d)),
+            insets: EdgeInsets.only(
+              left: 30.0,
+              right: 30,
+            ),
           ),
         ),
-      ),
-      textTheme: TextTheme(
-        headline4: TextStyle(color: Color(0xff080401), fontSize: 20.0, fontFamily: "Raleway", fontWeight: FontWeight.normal),
-        headline5: TextStyle(color: Color(0xff4c4f59), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
-        headline6: TextStyle(color: Color(0xff4c4f59), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.w300),
-        subtitle1: TextStyle(color: Color(0xff080401), fontSize: 20, fontFamily: "Raleway", fontWeight: FontWeight.bold),
-        subtitle2: TextStyle(color: Color(0xff080401), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.bold),
-        bodyText2: TextStyle(color: Color(0xff080401), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
-        bodyText1: TextStyle(color: Color(0xff4c4f59), fontSize: 14, fontFamily: "Raleway", fontWeight: FontWeight.w400),
-        caption: TextStyle(color: Color(0xff4c4f59), fontSize: 16, fontFamily: "Raleway"),
-      ),
-      tabBarTheme: TabBarTheme(
-        labelColor: Color(0xff080401),
-        unselectedLabelColor: Color(0xff4c4f59),
-        labelPadding: const EdgeInsets.fromLTRB(18.0, 0.0, 18.0, 10.0),
-        labelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
-        unselectedLabelStyle: TextStyle(fontSize: 15.0, fontFamily: "Raleway"),
-        indicatorSize: TabBarIndicatorSize.label,
-        indicator: DashedUnderlineIndicator(
-          width: 30.0,
-          dashSpace: 0,
-          borderSide: BorderSide(width: 6.0, color: Color(0xff3c404d)),
-          insets: EdgeInsets.only(
-            left: 30.0,
-            right: 30,
-          ),
+        buttonBarTheme: ButtonBarThemeData(
+          buttonPadding: EdgeInsets.all(0.0),
         ),
-      ),
-      buttonBarTheme: ButtonBarThemeData(
-        buttonPadding: EdgeInsets.all(0.0),
-      ),
+        buttonTheme: ButtonThemeData(
+            buttonColor: Color(0xffe2e5f3),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(18.0),
+              side: BorderSide(
+                color: Colors.transparent,
+              ),
+            ),
+            textTheme: ButtonTextTheme.accent
+        )
     );
   }
 
   static ThemeData getThemeFromPreferences(bool automatic, bool dark) {
     DateTime now = DateTime.now();
     if (automatic) {
-      if (now.hour >= 20 || now.hour < 8) return AppTheme.darkTheme();
-      else return AppTheme.lightTheme();
+      if (now.hour >= 20 || now.hour < 8)
+        return AppTheme.darkTheme();
+      else
+        return AppTheme.lightTheme();
     } else {
-      if (dark) return AppTheme.darkTheme();
-      else return AppTheme.lightTheme();
+      if (dark)
+        return AppTheme.darkTheme();
+      else
+        return AppTheme.lightTheme();
     }
   }
-
 }


### PR DESCRIPTION
Close #60 

The user can select favorite teams in the club page. Once it's done, he can see favorite teams first on the dashboard. To indicate the user that a team is favorite on the dashboard, there are several solutions (see screenshots). The last commit implements the third solution, the one with the non clickable star which is personally my preferred solution.

What do you think ?

<img src="https://user-images.githubusercontent.com/67117547/87073609-f47e9d00-c21d-11ea-89ef-f8bb02c97c0e.png" height=400>
<img src="https://user-images.githubusercontent.com/67117547/87073613-f6486080-c21d-11ea-9d50-40bee794220d.png" height=400>
<img src="https://user-images.githubusercontent.com/67117547/87073619-f7798d80-c21d-11ea-9bbc-2dbfa6bc51e3.png" height=400>


