### PR TITLE
Start to create team details page

### DIFF
--- a/lib/pages/club-details/teams/club_team.dart
+++ b/lib/pages/club-details/teams/club_team.dart
@@ -7,14 +7,16 @@ import 'package:v34/commons/cards/titled_card.dart';
 import 'package:v34/commons/graphs/arc.dart';
 import 'package:v34/commons/graphs/line_graph.dart';
 import 'package:v34/commons/loading.dart';
+import 'package:v34/commons/router.dart';
+import 'package:v34/models/team.dart';
 import 'package:v34/pages/club-details/blocs/club_team.bloc.dart';
+import 'package:v34/pages/team-details/team_detail_page.dart';
 import 'package:v34/repositories/repository.dart';
 
 class ClubTeam extends StatefulWidget {
-  final String code;
-  final String name;
+  final Team team;
 
-  ClubTeam({this.code, this.name});
+  ClubTeam({@required this.team});
 
   @override
   _ClubTeamState createState() => _ClubTeamState();
@@ -27,7 +29,7 @@ class _ClubTeamState extends State<ClubTeam> {
   void initState() {
     super.initState();
     _teamBloc = TeamBloc(repository: RepositoryProvider.of<Repository>(context))
-      ..add(TeamLoadAverageSlidingResult(code: widget.code, last: 100, count: 3));
+      ..add(TeamLoadAverageSlidingResult(code: widget.team.code, last: 100, count: 3));
   }
 
   @override
@@ -40,8 +42,9 @@ class _ClubTeamState extends State<ClubTeam> {
   Widget build(BuildContext context) {
     final double miniGraphHeight = 60;
     return TitledCard(
-      title: widget.name,
+      title: widget.team.name,
       bodyPadding: EdgeInsets.only(top: 18, bottom: 18, right: 8, left: 16),
+      onTap: () => Router.push(context: context, builder: (_) => TeamDetailPage(team: widget.team)),
       body: BlocBuilder(
         bloc: _teamBloc,
         builder: (context, state) {

--- a/lib/pages/club-details/teams/club_teams.dart
+++ b/lib/pages/club-details/teams/club_teams.dart
@@ -39,8 +39,7 @@ class _ClubTeamsState extends State<ClubTeams> {
             delegate: SliverChildBuilderDelegate((context, index) {
               return (state is ClubTeamsLoaded)
                   ? ClubTeam(
-                      code: state.teams[index].code,
-                      name: state.teams[index].name,
+                      team: state.teams[index]
                     )
                   : Loading();
             },

--- a/lib/pages/dashboard/dashboard_club_teams.dart
+++ b/lib/pages/dashboard/dashboard_club_teams.dart
@@ -5,8 +5,10 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:v34/commons/loading.dart';
+import 'package:v34/commons/router.dart';
 import 'package:v34/pages/club-details/blocs/club_teams.bloc.dart';
 import 'package:v34/pages/dashboard/team_card.dart';
+import 'package:v34/pages/team-details/team_detail_page.dart';
 import 'package:v34/repositories/repository.dart';
 
 final Random random = Random.secure();
@@ -78,6 +80,7 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
                             currentlyDisplayed: _currentIndex == index,
                             team: state.teams[index],
                             distance: _currentTeamPage - index,
+                            onTap: () => Router.push(context: context, builder: (_) => TeamDetailPage(team: state.teams[index])),
                           ),
                         );
                       },

--- a/lib/pages/dashboard/team_card.dart
+++ b/lib/pages/dashboard/team_card.dart
@@ -12,8 +12,9 @@ class TeamCard extends StatefulWidget {
   final bool currentlyDisplayed;
   final double distance;
   final double cardHeight = 190;
+  final Function onTap;
 
-  TeamCard({@required this.team, @required this.currentlyDisplayed, @required this.distance});
+  TeamCard({@required this.team, @required this.currentlyDisplayed, @required this.distance, this.onTap});
 
   @override
   _TeamCardState createState() => _TeamCardState();
@@ -102,6 +103,7 @@ class _TeamCardState extends State<TeamCard> {
               height: cardBodyHeight,
               child: Row(children: _getPodiumWidget(state)),
             ),
+            onTap: widget.onTap,
           ),
         );
       },

--- a/lib/pages/team-details/results/team_results.dart
+++ b/lib/pages/team-details/results/team_results.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/cupertino.dart';
+import 'package:v34/models/team.dart';
+
+class TeamResults extends StatefulWidget {
+  final Team team;
+
+  const TeamResults({Key key, @required this.team}) : super(key: key);
+
+  @override
+  _TeamResultsState createState() => _TeamResultsState();
+
+}
+
+class _TeamResultsState extends State<TeamResults> {
+  @override
+  Widget build(BuildContext context) {
+    return SliverList(
+      delegate: SliverChildListDelegate([]),
+    );
+  }
+
+}

--- a/lib/pages/team-details/team_detail_page.dart
+++ b/lib/pages/team-details/team_detail_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/cupertino.dart';
+import 'package:v34/commons/app_bar/app_bar_with_image.dart';
+import 'package:v34/commons/favorite/favorite.dart';
+import 'package:v34/commons/text_tab_bar.dart';
+import 'package:v34/models/team.dart';
+import 'package:v34/pages/team-details/results/team_results.dart';
+
+class TeamDetailPage extends StatefulWidget {
+  final Team team;
+
+  const TeamDetailPage({Key key, @required this.team}) : super(key: key);
+
+  @override
+  _TeamDetailPageState createState() => _TeamDetailPageState();
+}
+
+class _TeamDetailPageState extends State<TeamDetailPage> {
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBarWithImage(
+      widget.team.code,
+      "hero-logo-${widget.team.code}",
+      subTitle: widget.team.name,
+      logoUrl: widget.team.clubLogoUrl,
+      tabs: [
+        TextTab("Résultats", TeamResults(team: widget.team)),
+      ],
+      favorite: Favorite(
+        widget.team.favorite,
+        widget.team.code,
+        FavoriteType.Team,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Close #62 
I've done a page for team details. The code of the team is currently displayed as the title of the page to avoid text overflow when the team's name is too long.