### PR TITLE
Use the system preferences when the automatic dark theme option is on

### DIFF
--- a/lib/commons/blocs/preferences_bloc.dart
+++ b/lib/commons/blocs/preferences_bloc.dart
@@ -32,14 +32,12 @@ class PreferencesLoadingState extends PreferencesState {}
 
 class PreferencesSavingState extends PreferencesState {}
 
-class PreferencesLoadedState extends PreferencesState {
+class PreferencesUpdatedState extends PreferencesState {
   final bool useAutomaticTheme;
   final bool useDarkTheme;
 
-  PreferencesLoadedState({@required this.useAutomaticTheme, @required this.useDarkTheme});
+  PreferencesUpdatedState({@required this.useAutomaticTheme, @required this.useDarkTheme});
 }
-
-class PreferencesSavedState extends PreferencesState {}
 
 // ----- BLOC -----
 
@@ -61,7 +59,7 @@ class PreferencesBloc extends Bloc<PreferencesEvent, PreferencesState> {
     if (event is PreferencesLoadEvent) {
       yield PreferencesLoadingState();
       SharedPreferences preferences = await _getPreferences();
-      yield PreferencesLoadedState(
+      yield PreferencesUpdatedState(
         useAutomaticTheme: preferences.getBool("automatic_theme") ?? false,
         useDarkTheme: preferences.getBool("dark_theme") ?? false
       );
@@ -72,7 +70,10 @@ class PreferencesBloc extends Bloc<PreferencesEvent, PreferencesState> {
         preferences.setBool("automatic_theme", event.useAutomaticTheme);
       if (event.useDarkTheme != null)
         preferences.setBool("dark_theme", event.useDarkTheme);
-      yield PreferencesSavedState();
+      yield PreferencesUpdatedState(
+        useAutomaticTheme: preferences.getBool("automatic_theme") ?? false,
+        useDarkTheme: preferences.getBool("dark_theme") ?? false
+      );
     }
   }
 }

--- a/lib/commons/blocs/preferences_bloc.dart
+++ b/lib/commons/blocs/preferences_bloc.dart
@@ -1,0 +1,78 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// ----- EVENTS -----
+
+class PreferencesEvent extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+class PreferencesLoadEvent extends PreferencesEvent {}
+
+class PreferencesSaveEvent extends PreferencesEvent {
+  final bool automaticDarkTheme;
+  final bool darkTheme;
+
+  PreferencesSaveEvent({this.automaticDarkTheme, this.darkTheme});
+}
+
+// ----- STATES -----
+
+class PreferencesState extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+class PreferencesUninitializedState extends PreferencesState {}
+
+class PreferencesLoadingState extends PreferencesState {}
+
+class PreferencesSavingState extends PreferencesState {}
+
+class PreferencesLoadedState extends PreferencesState {
+  final bool automaticDarkTheme;
+  final bool darkTheme;
+
+  PreferencesLoadedState({@required this.automaticDarkTheme, @required this.darkTheme});
+}
+
+class PreferencesSavedState extends PreferencesState {}
+
+// ----- BLOC -----
+
+class PreferencesBloc extends Bloc<PreferencesEvent, PreferencesState> {
+  SharedPreferences _preferences;
+
+  Future<SharedPreferences> _getPreferences() async {
+    if (_preferences == null) {
+      _preferences = await SharedPreferences.getInstance();
+    }
+    return _preferences;
+  }
+
+  @override
+  PreferencesState get initialState => PreferencesUninitializedState();
+
+  @override
+  Stream<PreferencesState> mapEventToState(PreferencesEvent event) async* {
+    if (event is PreferencesLoadEvent) {
+      yield PreferencesLoadingState();
+      SharedPreferences preferences = await _getPreferences();
+      yield PreferencesLoadedState(
+        automaticDarkTheme: preferences.getBool("automatic_dark_theme"),
+        darkTheme: preferences.getBool("dark_theme")
+      );
+    } else if (event is PreferencesSaveEvent) {
+      yield PreferencesSavingState();
+      SharedPreferences preferences = await _getPreferences();
+      if (event.automaticDarkTheme != null)
+        preferences.setBool("automatic_dark_theme", event.automaticDarkTheme);
+      if (event.darkTheme != null)
+        preferences.setBool("dark_theme", event.darkTheme);
+      yield PreferencesSavedState();
+    }
+  }
+}

--- a/lib/commons/blocs/preferences_bloc.dart
+++ b/lib/commons/blocs/preferences_bloc.dart
@@ -13,10 +13,10 @@ class PreferencesEvent extends Equatable {
 class PreferencesLoadEvent extends PreferencesEvent {}
 
 class PreferencesSaveEvent extends PreferencesEvent {
-  final bool automaticDarkTheme;
-  final bool darkTheme;
+  final bool useAutomaticTheme;
+  final bool useDarkTheme;
 
-  PreferencesSaveEvent({this.automaticDarkTheme, this.darkTheme});
+  PreferencesSaveEvent({this.useAutomaticTheme, this.useDarkTheme});
 }
 
 // ----- STATES -----
@@ -33,10 +33,10 @@ class PreferencesLoadingState extends PreferencesState {}
 class PreferencesSavingState extends PreferencesState {}
 
 class PreferencesLoadedState extends PreferencesState {
-  final bool automaticDarkTheme;
-  final bool darkTheme;
+  final bool useAutomaticTheme;
+  final bool useDarkTheme;
 
-  PreferencesLoadedState({@required this.automaticDarkTheme, @required this.darkTheme});
+  PreferencesLoadedState({@required this.useAutomaticTheme, @required this.useDarkTheme});
 }
 
 class PreferencesSavedState extends PreferencesState {}
@@ -62,16 +62,16 @@ class PreferencesBloc extends Bloc<PreferencesEvent, PreferencesState> {
       yield PreferencesLoadingState();
       SharedPreferences preferences = await _getPreferences();
       yield PreferencesLoadedState(
-        automaticDarkTheme: preferences.getBool("automatic_dark_theme"),
-        darkTheme: preferences.getBool("dark_theme")
+        useAutomaticTheme: preferences.getBool("automatic_theme") ?? false,
+        useDarkTheme: preferences.getBool("dark_theme") ?? false
       );
     } else if (event is PreferencesSaveEvent) {
       yield PreferencesSavingState();
       SharedPreferences preferences = await _getPreferences();
-      if (event.automaticDarkTheme != null)
-        preferences.setBool("automatic_dark_theme", event.automaticDarkTheme);
-      if (event.darkTheme != null)
-        preferences.setBool("dark_theme", event.darkTheme);
+      if (event.useAutomaticTheme != null)
+        preferences.setBool("automatic_theme", event.useAutomaticTheme);
+      if (event.useDarkTheme != null)
+        preferences.setBool("dark_theme", event.useDarkTheme);
       yield PreferencesSavedState();
     }
   }

--- a/lib/commons/blocs/preferences_bloc.dart
+++ b/lib/commons/blocs/preferences_bloc.dart
@@ -42,30 +42,21 @@ class PreferencesUpdatedState extends PreferencesState {
 // ----- BLOC -----
 
 class PreferencesBloc extends Bloc<PreferencesEvent, PreferencesState> {
-  SharedPreferences _preferences;
-
-  Future<SharedPreferences> _getPreferences() async {
-    if (_preferences == null) {
-      _preferences = await SharedPreferences.getInstance();
-    }
-    return _preferences;
-  }
 
   @override
   PreferencesState get initialState => PreferencesUninitializedState();
 
   @override
   Stream<PreferencesState> mapEventToState(PreferencesEvent event) async* {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
     if (event is PreferencesLoadEvent) {
       yield PreferencesLoadingState();
-      SharedPreferences preferences = await _getPreferences();
       yield PreferencesUpdatedState(
         useAutomaticTheme: preferences.getBool("automatic_theme") ?? false,
         useDarkTheme: preferences.getBool("dark_theme") ?? false
       );
     } else if (event is PreferencesSaveEvent) {
       yield PreferencesSavingState();
-      SharedPreferences preferences = await _getPreferences();
       if (event.useAutomaticTheme != null)
         preferences.setBool("automatic_theme", event.useAutomaticTheme);
       if (event.useDarkTheme != null)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,8 +59,8 @@ class _V34State extends State<V34> {
   }
 
   Widget _buildMaterialApp(PreferencesLoadedState state) {
-    bool automatic = state.automaticDarkTheme;
-    bool dark = state.darkTheme;
+    bool automatic = state.useAutomaticTheme;
+    bool dark = state.useDarkTheme;
     return MaterialApp(
       title: 'Volley34',
       theme: AppTheme.getNormalThemeFromPreferences(automatic, dark),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,11 +45,6 @@ class _V34State extends State<V34> {
   void initState() {
     super.initState();
     _preferencesBloc.add(PreferencesLoadEvent());
-    _preferencesBloc.listen((state) {
-      if (state is PreferencesSavedState) {
-        _preferencesBloc.add(PreferencesLoadEvent());
-      }
-    });
   }
 
   @override
@@ -58,7 +53,7 @@ class _V34State extends State<V34> {
     _preferencesBloc.close();
   }
 
-  Widget _buildMaterialApp(PreferencesLoadedState state) {
+  Widget _buildMaterialApp(PreferencesUpdatedState state) {
     bool automatic = state.useAutomaticTheme;
     bool dark = state.useDarkTheme;
     return MaterialApp(
@@ -75,7 +70,7 @@ class _V34State extends State<V34> {
       create: (context) => _preferencesBloc,
       child: BlocBuilder<PreferencesBloc, PreferencesState>(
         builder: (context, state) {
-          if (state is PreferencesLoadedState) {
+          if (state is PreferencesUpdatedState) {
             return RepositoryProvider(
               create: (context) => Repository(
                 ClubProvider(),

--- a/lib/pages/preferences_page.dart
+++ b/lib/pages/preferences_page.dart
@@ -29,7 +29,7 @@ class _PreferencesPageState extends State<PreferencesPage> {
   Widget _buildPreferencesContent() {
     return BlocBuilder<PreferencesBloc, PreferencesState>(
       builder: (context, state) {
-        if (state is PreferencesLoadedState) {
+        if (state is PreferencesUpdatedState) {
           return ListView(
             children: <Widget>[
               _buildDarkModeOption(state),
@@ -52,7 +52,7 @@ class _PreferencesPageState extends State<PreferencesPage> {
     );
   }
   
-  Widget _buildDarkModeOption(PreferencesLoadedState state) {
+  Widget _buildDarkModeOption(PreferencesUpdatedState state) {
     if (state.useAutomaticTheme) {
       return ListTile(
         title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
@@ -74,7 +74,7 @@ class _PreferencesPageState extends State<PreferencesPage> {
     }
   }
   
-  Widget _buildAutomaticModeOption(PreferencesLoadedState state) {
+  Widget _buildAutomaticModeOption(PreferencesUpdatedState state) {
     return SwitchListTile(
       contentPadding: EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
       title: Text("Mode sombre automatique", style: Theme.of(context).textTheme.bodyText2),

--- a/lib/pages/preferences_page.dart
+++ b/lib/pages/preferences_page.dart
@@ -1,6 +1,7 @@
-import 'package:animated_theme_switcher/animated_theme_switcher.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:v34/commons/blocs/preferences_bloc.dart';
 import 'package:v34/commons/loading.dart';
 import 'package:v34/theme.dart';
 
@@ -10,102 +11,80 @@ class PreferencesPage extends StatefulWidget {
 }
 
 class _PreferencesPageState extends State<PreferencesPage> {
-  Future<SharedPreferences> _preferences;
 
   @override
   void initState() {
     super.initState();
-    _preferences = SharedPreferences.getInstance();
   }
 
   @override
   Widget build(BuildContext context) {
-    return ThemeSwitchingArea(
-      child: Scaffold(
-        backgroundColor: Theme.of(context).primaryColor,
-        appBar: AppBar(title: Text("Préférences")),
-        body: _buildPreferencesContent(),
-      ),
+    return Scaffold(
+      backgroundColor: Theme.of(context).primaryColor,
+      appBar: AppBar(title: Text("Préférences")),
+      body: _buildPreferencesContent(),
     );
   }
 
   Widget _buildPreferencesContent() {
-    return FutureBuilder<SharedPreferences>(
-      future: _preferences,
-      builder: (context, snapshot) {
-        switch (snapshot.connectionState) {
-          case ConnectionState.waiting:
-            return Center(
-              child: Column(
+    return BlocBuilder<PreferencesBloc, PreferencesState>(
+      bloc: BlocProvider.of<PreferencesBloc>(context),
+      builder: (context, state) {
+        if (state is PreferencesLoadedState) {
+          return ListView.builder(
+            itemBuilder: (context, index) => _buildPreferencesItem(index, state),
+          );
+        } else {
+          return Center(
+            child: Column(
                 children: <Widget>[
                   Text("Chargement de vos préférences..."),
                   Loading()
                 ]
-              ),
-            );
-          case ConnectionState.done:
-            return ListView.builder(
-              itemBuilder: (context, index) => _buildPreferencesItem(index, snapshot),
-            );
-          default:
-            return Container();
+            ),
+          );
         }
       },
     );
   }
 
-  Widget _buildPreferencesItem(int index, AsyncSnapshot<SharedPreferences> snapshot) {
+  Widget _buildPreferencesItem(int index, PreferencesLoadedState state) {
     if (index % 2 == 0) {
       index = index ~/ 2;
       switch (index) {
         case 0:
-          return ThemeSwitcher(
-            clipper: ThemeSwitcherCircleClipper(),
-            builder: (context) {
-              bool automaticDarkTheme = snapshot.data.getBool('automatic_dark_theme') ?? false;
-              if (automaticDarkTheme) {
-                return ListTile(
-                  title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
-                  leading: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
-                  trailing: Text(
-                    "Mode sombre automatique activé",
-                    style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10),
-                  ),
-                );
-              } else {
-                return SwitchListTile(
-                  title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
-                  secondary: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
-                  value: snapshot.data.getBool('dark_theme') ?? false,
-                  onChanged: (dark) {
-                    if (dark) ThemeSwitcher.of(context).changeTheme(theme: AppTheme.darkTheme());
-                    else ThemeSwitcher.of(context).changeTheme(theme: AppTheme.lightTheme());
-                    snapshot.data.setBool('dark_theme', dark);
-                  }
-                );
+          if (state.automaticDarkTheme) {
+            return ListTile(
+              title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
+              leading: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
+              trailing: Text(
+                "Mode sombre automatique activé",
+                style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10),
+              ),
+            );
+          } else {
+            return SwitchListTile(
+              title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
+              secondary: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
+              value: state.darkTheme,
+              onChanged: (dark) {
+                BlocProvider.of<PreferencesBloc>(context).add(PreferencesSaveEvent(darkTheme: dark));
               }
-            },
-          );
+            );
+          }
+          break;
         case 1:
-          return ThemeSwitcher(
-            clipper: ThemeSwitcherCircleClipper(),
-            builder: (context) {
-              return SwitchListTile(
-                contentPadding: EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
-                title: Text("Mode sombre automatique", style: Theme.of(context).textTheme.bodyText2),
-                subtitle: Text(
-                  "Cette option active automatiquement le mode sombre le soir et le désactive le matin.",
-                    style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10)
-                ),
-                secondary: Icon(Icons.access_time, color: Theme.of(context).accentColor),
-                value: snapshot.data.getBool('automatic_dark_theme') ?? false,
-                onChanged: (automatic) {
-                  bool dark = snapshot.data.getBool("dark_theme") ?? false;
-                  ThemeData theme = AppTheme.getThemeFromPreferences(automatic, dark);
-                  ThemeSwitcher.of(context).changeTheme(theme: theme);
-                  snapshot.data.setBool('automatic_dark_theme', automatic);
-                },
-              );
+          return SwitchListTile(
+            contentPadding: EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
+            title: Text("Mode sombre automatique", style: Theme.of(context).textTheme.bodyText2),
+            subtitle: Text(
+                "Cette option active automatiquement le mode sombre en fonction des préférences de votre appareil.",
+                style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10)
+            ),
+            secondary: Icon(Icons.access_time, color: Theme.of(context).accentColor),
+            value: state.automaticDarkTheme,
+            onChanged: (automatic) {
+              BlocProvider.of<PreferencesBloc>(context).add(PreferencesSaveEvent(automaticDarkTheme: automatic));
             },
           );
         default:

--- a/lib/pages/preferences_page.dart
+++ b/lib/pages/preferences_page.dart
@@ -28,11 +28,15 @@ class _PreferencesPageState extends State<PreferencesPage> {
 
   Widget _buildPreferencesContent() {
     return BlocBuilder<PreferencesBloc, PreferencesState>(
-      bloc: BlocProvider.of<PreferencesBloc>(context),
       builder: (context, state) {
         if (state is PreferencesLoadedState) {
-          return ListView.builder(
-            itemBuilder: (context, index) => _buildPreferencesItem(index, state),
+          return ListView(
+            children: <Widget>[
+              _buildDarkModeOption(state),
+              Divider(height: 1.0),
+              _buildAutomaticModeOption(state),
+              Divider(height: 1.0)
+            ],
           );
         } else {
           return Center(
@@ -47,52 +51,42 @@ class _PreferencesPageState extends State<PreferencesPage> {
       },
     );
   }
-
-  Widget _buildPreferencesItem(int index, PreferencesLoadedState state) {
-    if (index % 2 == 0) {
-      index = index ~/ 2;
-      switch (index) {
-        case 0:
-          if (state.automaticDarkTheme) {
-            return ListTile(
-              title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
-              leading: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
-              trailing: Text(
-                "Mode sombre automatique activé",
-                style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10),
-              ),
-            );
-          } else {
-            return SwitchListTile(
-              title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
-              secondary: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
-              value: state.darkTheme,
-              onChanged: (dark) {
-                BlocProvider.of<PreferencesBloc>(context).add(PreferencesSaveEvent(darkTheme: dark));
-              }
-            );
-          }
-          break;
-        case 1:
-          return SwitchListTile(
-            contentPadding: EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
-            title: Text("Mode sombre automatique", style: Theme.of(context).textTheme.bodyText2),
-            subtitle: Text(
-                "Cette option active automatiquement le mode sombre en fonction des préférences de votre appareil.",
-                style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10)
-            ),
-            secondary: Icon(Icons.access_time, color: Theme.of(context).accentColor),
-            value: state.automaticDarkTheme,
-            onChanged: (automatic) {
-              BlocProvider.of<PreferencesBloc>(context).add(PreferencesSaveEvent(automaticDarkTheme: automatic));
-            },
-          );
-        default:
-          return null;
-      }
+  
+  Widget _buildDarkModeOption(PreferencesLoadedState state) {
+    if (state.useAutomaticTheme) {
+      return ListTile(
+        title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
+        leading: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
+        trailing: Text(
+          "Mode sombre automatique activé",
+          style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10),
+        ),
+      );
     } else {
-      return Divider(height: 1.0);
+      return SwitchListTile(
+          title: Text("Mode sombre", style: Theme.of(context).textTheme.bodyText2),
+          secondary: Icon(Icons.brightness_6, color: Theme.of(context).accentColor,),
+          value: state.useDarkTheme,
+          onChanged: (isDark) {
+            BlocProvider.of<PreferencesBloc>(context).add(PreferencesSaveEvent(useDarkTheme: isDark));
+          }
+      );
     }
   }
-
+  
+  Widget _buildAutomaticModeOption(PreferencesLoadedState state) {
+    return SwitchListTile(
+      contentPadding: EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
+      title: Text("Mode sombre automatique", style: Theme.of(context).textTheme.bodyText2),
+      subtitle: Text(
+          "Cette option active automatiquement le mode sombre en fonction des préférences de votre appareil.",
+          style: TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 10)
+      ),
+      secondary: Icon(Icons.access_time, color: Theme.of(context).accentColor),
+      value: state.useAutomaticTheme,
+      onChanged: (isAutomatic) {
+        BlocProvider.of<PreferencesBloc>(context).add(PreferencesSaveEvent(useAutomaticTheme: isAutomatic));
+      },
+    );
+  }
 }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -163,16 +163,12 @@ class AppTheme {
   }
 
   static ThemeData getNormalThemeFromPreferences(bool isAutomatic, bool isDark) {
-    if (isAutomatic) return AppTheme.lightTheme();
-    else {
-      if (isDark) return AppTheme.darkTheme();
-      else return AppTheme.lightTheme();
-    }
+    if (isAutomatic) return lightTheme();
+    else return isDark ? darkTheme() : lightTheme();
   }
 
   static ThemeData getDarkThemeFromPreferences(bool isAutomatic) {
-    if (isAutomatic) return AppTheme.darkTheme();
-    else return null;
+    return isAutomatic ? darkTheme() : null;
   }
 
 }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -162,16 +162,16 @@ class AppTheme {
     );
   }
 
-  static ThemeData getNormalThemeFromPreferences(bool automatic, bool dark) {
-    if (automatic) return AppTheme.lightTheme();
+  static ThemeData getNormalThemeFromPreferences(bool isAutomatic, bool isDark) {
+    if (isAutomatic) return AppTheme.lightTheme();
     else {
-      if (dark) return AppTheme.darkTheme();
+      if (isDark) return AppTheme.darkTheme();
       else return AppTheme.lightTheme();
     }
   }
 
-  static ThemeData getDarkThemeFromPreferences(bool automatic) {
-    if (automatic) return AppTheme.darkTheme();
+  static ThemeData getDarkThemeFromPreferences(bool isAutomatic) {
+    if (isAutomatic) return AppTheme.darkTheme();
     else return null;
   }
 

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -162,18 +162,17 @@ class AppTheme {
     );
   }
 
-  static ThemeData getThemeFromPreferences(bool automatic, bool dark) {
-    DateTime now = DateTime.now();
-    if (automatic) {
-      if (now.hour >= 20 || now.hour < 8)
-        return AppTheme.darkTheme();
-      else
-        return AppTheme.lightTheme();
-    } else {
-      if (dark)
-        return AppTheme.darkTheme();
-      else
-        return AppTheme.lightTheme();
+  static ThemeData getNormalThemeFromPreferences(bool automatic, bool dark) {
+    if (automatic) return AppTheme.lightTheme();
+    else {
+      if (dark) return AppTheme.darkTheme();
+      else return AppTheme.lightTheme();
     }
   }
+
+  static ThemeData getDarkThemeFromPreferences(bool automatic) {
+    if (automatic) return AppTheme.darkTheme();
+    else return null;
+  }
+
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -15,13 +15,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.39.8"
-  animated_theme_switcher:
-    dependency: "direct main"
-    description:
-      name: animated_theme_switcher
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.6"
   archive:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,6 @@ dependencies:
   radial_button: ^1.0.0
   flushbar: ^1.10.4
   simple_gravatar: ^1.0.5
-  animated_theme_switcher: ^1.0.5
   shared_preferences: ^0.5.7+3
   auto_size_text: ^2.1.0
   


### PR DESCRIPTION
Close #63 

I used the `darkTheme` attribute of `MaterialApp` to be able to use system preferences when the automatic dark theme option is on. I also used a `PreferencesBloc` which is cleaner than the previous solution.

I also took the advantage of the opportunity to remove the animation I had previously added. It was not really relevant.