### PR TITLE
Displays the agenda for one month for favorited teams of a club

### DIFF
--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -54,6 +54,13 @@ class Event {
         return EventType.Unknown;
     }
   }
+
+  @override
+  int get hashCode => name.hashCode + date.hashCode;
+
+  @override
+  bool operator ==(other) => this.hashCode == other.hashCode;
+
 }
 
 enum EventType { Match, Tournament, Meeting, Unknown }

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -1,7 +1,8 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter/cupertino.dart';
 
 @immutable
-class Event {
+class Event extends Equatable {
   // Common
   final DateTime date;
   final String place;
@@ -56,10 +57,7 @@ class Event {
   }
 
   @override
-  int get hashCode => name.hashCode + date.hashCode;
-
-  @override
-  bool operator ==(other) => this.hashCode == other.hashCode;
+  List<Object> get props => [name, date];
 
 }
 

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -26,7 +26,7 @@ class Event {
     if (json["MatchCode"] != null) {
       return Event(
         date: DateTime.parse(json["DateMatch"]),
-        name: json["CalendarEventName"],
+        name: json["CalendarEventName"] ?? json["LibelleMatch"],
         place: json["NomGymnase"],
         hostName: json["NomLocaux"],
         visitorName: json["NomVisiteurs"],

--- a/lib/pages/dashboard/blocs/agenda_bloc.dart
+++ b/lib/pages/dashboard/blocs/agenda_bloc.dart
@@ -90,13 +90,14 @@ class AgendaBloc extends Bloc<AgendaEvent, AgendaState> {
       yield AgendaLoaded(events);
     }
     else if (event is LoadTeamsMonthAgenda) {
-      List<Event> allEvents = [];
+      Set<Event> allEvents = Set();
       for (String teamCode in event.teamCodes) {
         List<Event> events = await repository.loadTeamMonthAgenda(teamCode);
         allEvents.addAll(events);
       }
-      allEvents.sort((event1, event2) => event1.date.compareTo(event2.date));
-      yield AgendaLoaded(allEvents);
+      List<Event> eventList = allEvents.toList();
+      eventList.sort((event1, event2) => event1.date.compareTo(event2.date));
+      yield AgendaLoaded(eventList);
     }
   }
 }

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:v34/commons/page/main_page.dart';
 import 'package:v34/models/club.dart';
 import 'package:v34/commons/paragraph.dart';
+import 'package:v34/models/team.dart';
 import 'package:v34/pages/dashboard/widgets/dashboard_agenda.dart';
 import 'package:v34/pages/dashboard/widgets/dashboard_club_teams.dart';
 import 'package:v34/pages/dashboard/widgets/dashboard_clubs.dart';
@@ -14,6 +15,7 @@ class DashboardPage extends StatefulWidget {
 
 class _DashboardPageState extends State<DashboardPage> {
   Club _currentClub;
+  List<Team> _currentTeams;
 
   @override
   Widget build(BuildContext context) {
@@ -24,15 +26,26 @@ class _DashboardPageState extends State<DashboardPage> {
           Paragraph(title: "Vos clubs"),
           DashboardClubs(onClubChange: (club) => _selectCurrentClub(club)),
           Paragraph(title: "Vos équipes"),
-          if (_currentClub != null) DashboardClubTeams(club: _currentClub, onTeamFavoriteChange: (_) => _selectCurrentClub(_currentClub)),
+          if (_currentClub != null) DashboardClubTeams(
+            club: _currentClub,
+            onTeamFavoriteChange: (_) => _selectCurrentClub(_currentClub),
+            onTeamsLoaded: (teams) => _setCurrentTeams(teams),
+          ),
           Paragraph(title: "Votre agenda"),
-          DashboardAgenda()
+          if(_currentTeams != null) DashboardAgenda(teams: _currentTeams)
         ])
       )
     );
   }
 
   void _selectCurrentClub(Club club) {
-    setState(() => _currentClub = club);
+    setState(() {
+      _currentClub = club;
+      _currentTeams = null;
+    });
+  }
+
+  void _setCurrentTeams(List<Team> teams) {
+    setState(() => _currentTeams = teams);
   }
 }

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -1,11 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:v34/commons/loading.dart';
 import 'package:v34/commons/page/main_page.dart';
+import 'package:v34/commons/router.dart';
 import 'package:v34/models/club.dart';
 import 'package:v34/commons/paragraph.dart';
 import 'package:v34/models/team.dart';
+import 'package:v34/pages/club-details/blocs/club_teams.bloc.dart';
+import 'package:v34/pages/club-details/club_detail_page.dart';
 import 'package:v34/pages/dashboard/widgets/dashboard_agenda.dart';
 import 'package:v34/pages/dashboard/widgets/dashboard_club_teams.dart';
 import 'package:v34/pages/dashboard/widgets/dashboard_clubs.dart';
+import 'package:v34/repositories/repository.dart';
 
 class DashboardPage extends StatefulWidget {
 
@@ -15,7 +21,15 @@ class DashboardPage extends StatefulWidget {
 
 class _DashboardPageState extends State<DashboardPage> {
   Club _currentClub;
-  List<Team> _currentTeams;
+  ClubTeamsBloc _clubTeamsBloc;
+
+  @override
+  void initState() {
+    _clubTeamsBloc = ClubTeamsBloc(
+      repository: RepositoryProvider.of<Repository>(context),
+    );
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -24,28 +38,53 @@ class _DashboardPageState extends State<DashboardPage> {
       sliver: SliverList(
         delegate: SliverChildListDelegate.fixed([
           Paragraph(title: "Vos clubs"),
-          DashboardClubs(onClubChange: (club) => _selectCurrentClub(club)),
+          DashboardClubs(key: ValueKey("dashboard-clubs"), onClubChange: (club) => _selectCurrentClub(club)),
           Paragraph(title: "Vos équipes"),
-          if (_currentClub != null) DashboardClubTeams(
-            key: ValueKey("dashboard-club-teams-${hashList(_currentTeams)}"),
-            club: _currentClub,
-            onTeamsChange: (teams) => _selectCurrentTeams(teams),
-          ),
+          if (_currentClub != null) _buildDashboardElement(_teamsElement),
           Paragraph(title: "Votre agenda"),
-          if(_currentTeams != null) DashboardAgenda(teams: _currentTeams)
+          if (_currentClub != null) _buildDashboardElement(_agendaElement)
         ])
       )
     );
   }
 
-  void _selectCurrentClub(Club club) {
-    setState(() {
-      _currentClub = club;
-      _currentTeams = null;
-    });
+  Widget _teamsElement(List<Team> teams) {
+    if (teams.length > 0) {
+      return DashboardClubTeams(teams: teams, onFavoriteTeamsChange: () => _selectCurrentClub(_currentClub));
+    } else {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(28.0),
+          child: RaisedButton(
+            onPressed: () =>  Router.push(context: context, builder: (_) => ClubDetailPage(_currentClub)).then(
+              (_) => _selectCurrentClub(_currentClub),
+            ),
+            padding: EdgeInsets.all(12.0),
+            child: Text("Sélectionnez une équipe favorite")
+          ),
+        ),
+      );
+    }
   }
 
-  void _selectCurrentTeams(List<Team> teams) {
-    setState(() => _currentTeams = teams);
+  Widget _agendaElement(List<Team> teams) {
+    return DashboardAgenda(teams: teams);
   }
+
+  Widget _buildDashboardElement(Function toBuild) {
+    return BlocBuilder<ClubTeamsBloc, ClubTeamsState>(
+      bloc: _clubTeamsBloc,
+      builder: (context, state) {
+        if (state is ClubTeamsLoaded) {
+          return toBuild(state.teams);
+        } else return Container(height: 250, child: Loading());
+      }
+    );
+  }
+
+  void _selectCurrentClub(Club club) {
+    setState(() => _currentClub = club);
+    _clubTeamsBloc.add(ClubFavoriteTeamsLoadEvent(club.code));
+  }
+
 }

--- a/lib/pages/dashboard/dashoard_page.dart
+++ b/lib/pages/dashboard/dashoard_page.dart
@@ -27,9 +27,9 @@ class _DashboardPageState extends State<DashboardPage> {
           DashboardClubs(onClubChange: (club) => _selectCurrentClub(club)),
           Paragraph(title: "Vos équipes"),
           if (_currentClub != null) DashboardClubTeams(
+            key: ValueKey("dashboard-club-teams-${hashList(_currentTeams)}"),
             club: _currentClub,
-            onTeamFavoriteChange: (_) => _selectCurrentClub(_currentClub),
-            onTeamsLoaded: (teams) => _setCurrentTeams(teams),
+            onTeamsChange: (teams) => _selectCurrentTeams(teams),
           ),
           Paragraph(title: "Votre agenda"),
           if(_currentTeams != null) DashboardAgenda(teams: _currentTeams)
@@ -45,7 +45,7 @@ class _DashboardPageState extends State<DashboardPage> {
     });
   }
 
-  void _setCurrentTeams(List<Team> teams) {
+  void _selectCurrentTeams(List<Team> teams) {
     setState(() => _currentTeams = teams);
   }
 }

--- a/lib/pages/dashboard/widgets/dashboard_agenda.dart
+++ b/lib/pages/dashboard/widgets/dashboard_agenda.dart
@@ -2,12 +2,17 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:v34/commons/loading.dart';
+import 'package:v34/models/team.dart';
 import 'package:v34/pages/dashboard/blocs/agenda_bloc.dart';
 import 'package:v34/pages/dashboard/widgets/timeline/timeline.dart';
 import 'package:v34/pages/dashboard/widgets/timeline/timeline_items.dart';
 import 'package:v34/repositories/repository.dart';
 
 class DashboardAgenda extends StatefulWidget {
+  final List<Team> teams;
+
+  const DashboardAgenda({Key key, @required this.teams}) : super(key: key);
+
   @override
   DashboardAgendaState createState() => DashboardAgendaState();
 }
@@ -21,7 +26,7 @@ class DashboardAgendaState extends State<DashboardAgenda> with AutomaticKeepAliv
   void initState() {
     super.initState();
     _agendaBloc = AgendaBloc(repository: RepositoryProvider.of<Repository>(context));
-    _agendaBloc.add(AgendaLoadWeek(week: 0));
+    _agendaBloc.add(LoadTeamsMonthAgenda(teamCodes: widget.teams.map((team) => team.code).toList()));
   }
 
   Widget _buildTimeline(AgendaState state) {
@@ -42,7 +47,7 @@ class DashboardAgendaState extends State<DashboardAgenda> with AutomaticKeepAliv
         }),
       ]);
     } else {
-      return Center(child: Loading());
+      return Container(height: 250, child: Center(child: Loading()));
     }
   }
 

--- a/lib/pages/dashboard/widgets/dashboard_agenda.dart
+++ b/lib/pages/dashboard/widgets/dashboard_agenda.dart
@@ -26,7 +26,19 @@ class DashboardAgendaState extends State<DashboardAgenda> with AutomaticKeepAliv
   void initState() {
     super.initState();
     _agendaBloc = AgendaBloc(repository: RepositoryProvider.of<Repository>(context));
+    _loadTeamsMonthAgenda();
+  }
+
+  void _loadTeamsMonthAgenda() {
     _agendaBloc.add(LoadTeamsMonthAgenda(teamCodes: widget.teams.map((team) => team.code).toList()));
+  }
+
+  @override
+  void didUpdateWidget(DashboardAgenda oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!ListEquality().equals(widget.teams, oldWidget.teams)) {
+      _loadTeamsMonthAgenda();
+    }
   }
 
   Widget _buildTimeline(AgendaState state) {

--- a/lib/pages/dashboard/widgets/dashboard_club_teams.dart
+++ b/lib/pages/dashboard/widgets/dashboard_club_teams.dart
@@ -1,24 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
-import 'package:v34/commons/loading.dart';
-import 'package:v34/commons/router.dart';
-import 'package:v34/models/club.dart';
 import 'package:v34/models/team.dart';
-import 'package:v34/pages/club-details/blocs/club_teams.bloc.dart';
-import 'package:v34/pages/club-details/club_detail_page.dart';
 import 'package:v34/pages/dashboard/widgets/team_card.dart';
-import 'package:v34/repositories/repository.dart';
 
 typedef TeamFavoriteChangeCallback = void Function(Team team);
 
 class DashboardClubTeams extends StatefulWidget {
-  final Club club;
-  final Function(List<Team>) onTeamsChange;
+  final List<Team> teams;
+  final Function() onFavoriteTeamsChange;
   final double cardHeight = 240;
 
-  const DashboardClubTeams({Key key, this.club, this.onTeamsChange}) : super(key: key);
+  const DashboardClubTeams({Key key, @required this.teams, this.onFavoriteTeamsChange}) : super(key: key);
 
   @override
   _DashboardClubTeamsState createState() => _DashboardClubTeamsState();
@@ -30,7 +23,6 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
   PageController _pageController;
   int _currentIndex = 0;
   double _currentTeamPage = 0;
-  ClubTeamsBloc _clubTeamsBloc;
 
   @override
   void initState() {
@@ -42,90 +34,48 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
           _currentIndex = nextIndex;
         }
       });
-    _clubTeamsBloc = ClubTeamsBloc(
-      repository: RepositoryProvider.of<Repository>(context),
-    );
-    _clubTeamsBloc.listen((state) {
-      if (state is ClubTeamsLoaded) {
-        widget.onTeamsChange(state.teams);
-        if (_pageController.hasClients) {
-          _currentIndex = 0;
-          _pageController.jumpTo(0);
-        }
-      }
-    });
-    _clubTeamsBloc.add(ClubFavoriteTeamsLoadEvent(widget.club.code));
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return BlocBuilder<ClubTeamsBloc, ClubTeamsState>(
-      bloc: _clubTeamsBloc,
-      builder: (context, state) {
-        if (state is ClubTeamsLoaded) {
-          return Column(crossAxisAlignment: CrossAxisAlignment.center, children: <Widget>[
-            Container(
-              height: widget.cardHeight,
-              child: state.teams.length > 0
-                  ? PageView.builder(
-                      physics: const BouncingScrollPhysics(),
-                      controller: _pageController,
-                      itemCount: state.teams.length,
-                      itemBuilder: (context, index) {
-                        return Padding(
-                          padding: const EdgeInsets.only(left: 8.0, right: 0),
-                          child: TeamCard(
-                            currentlyDisplayed: _currentIndex == index,
-                            team: state.teams[index],
-                            distance: _currentTeamPage - index,
-                            onFavoriteChange: () => widget.onTeamsChange(null),
-                          ),
-                        );
-                      },
-                    )
-                  : Center(
-                      child: Padding(
-                        padding: const EdgeInsets.all(28.0),
-                        child: RaisedButton(
-                          onPressed: () =>  Router.push(context: context, builder: (_) => ClubDetailPage(widget.club)).then(
-                            (_) => widget.onTeamsChange(null),
-                          ),
-                          padding: EdgeInsets.all(12.0),
-                          child: Text(
-                            "Sélectionnez une équipe favorite",
-                          ),
-                        ),
-                      ),
-                    ),
+    return Column(crossAxisAlignment: CrossAxisAlignment.center, children: <Widget>[
+      Container(
+        height: widget.cardHeight,
+        child: PageView.builder(
+          physics: const BouncingScrollPhysics(),
+          controller: _pageController,
+          itemCount: widget.teams.length,
+          itemBuilder: (context, index) {
+            return Padding(
+              padding: const EdgeInsets.only(left: 8.0, right: 0),
+              child: TeamCard(
+                currentlyDisplayed: _currentIndex == index,
+                team: widget.teams[index],
+                distance: _currentTeamPage - index,
+                onFavoriteChange: widget.onFavoriteTeamsChange,
+              ),
+            );
+          },
+        )
+      ),
+      if (widget.teams.length > 1) Padding(
+        padding: EdgeInsets.only(top: 16.0),
+        child: Center(
+          child: SmoothPageIndicator(
+            controller: _pageController,
+            count: widget.teams.length,
+            effect: WormEffect(
+              dotHeight: 8,
+              dotWidth: 8,
+              dotColor: Theme.of(context).cardTheme.color,
+              activeDotColor: Theme.of(context).accentColor,
             ),
-            if (state.teams.length > 1)
-              Padding(
-                  padding: EdgeInsets.only(top: 16.0),
-                  child: Center(
-                    child: SmoothPageIndicator(
-                      controller: _pageController,
-                      count: state.teams.length,
-                      effect: WormEffect(
-                        dotHeight: 8,
-                        dotWidth: 8,
-                        dotColor: Theme.of(context).cardTheme.color,
-                        activeDotColor: Theme.of(context).accentColor,
-                      ),
-                    ),
-                  ))
-          ]);
-        } else if (state is ClubTeamsLoading) {
-          return Container(
-            height: widget.cardHeight,
-            child: Loading(),
-          );
-        } else {
-          return Container(height: widget.cardHeight);
-        }
-      },
-    );
+          ),
+        )
+      )
+    ]);
   }
 
   @override

--- a/lib/pages/dashboard/widgets/dashboard_club_teams.dart
+++ b/lib/pages/dashboard/widgets/dashboard_club_teams.dart
@@ -15,10 +15,11 @@ typedef TeamFavoriteChangeCallback = void Function(Team team);
 
 class DashboardClubTeams extends StatefulWidget {
   final Club club;
+  final Function(List<Team>) onTeamsLoaded;
   final double cardHeight = 240;
   final TeamFavoriteChangeCallback onTeamFavoriteChange;
 
-  const DashboardClubTeams({@required this.club, this.onTeamFavoriteChange});
+  const DashboardClubTeams({@required this.club, this.onTeamFavoriteChange, this.onTeamsLoaded});
 
   @override
   _DashboardClubTeamsState createState() => _DashboardClubTeamsState();
@@ -46,9 +47,12 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
       repository: RepositoryProvider.of<Repository>(context),
     );
     _clubTeamsBloc.listen((state) {
-      if (state is ClubTeamsLoaded && _pageController.hasClients) {
-        _currentIndex = 0;
-        _pageController.jumpTo(0);
+      if (state is ClubTeamsLoaded) {
+        widget.onTeamsLoaded(state.teams);
+        if (_pageController.hasClients) {
+          _currentIndex = 0;
+          _pageController.jumpTo(0);
+        }
       }
     });
     _loadFavoriteTeams();
@@ -58,7 +62,7 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
   @override
   void didUpdateWidget(DashboardClubTeams oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _loadFavoriteTeams();
+    if (oldWidget.club.code != widget.club.code) _loadFavoriteTeams();
   }
 
   void _loadFavoriteTeams() {
@@ -137,4 +141,5 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
 
   @override
   bool get wantKeepAlive => true;
+
 }

--- a/lib/pages/dashboard/widgets/dashboard_club_teams.dart
+++ b/lib/pages/dashboard/widgets/dashboard_club_teams.dart
@@ -15,11 +15,10 @@ typedef TeamFavoriteChangeCallback = void Function(Team team);
 
 class DashboardClubTeams extends StatefulWidget {
   final Club club;
-  final Function(List<Team>) onTeamsLoaded;
+  final Function(List<Team>) onTeamsChange;
   final double cardHeight = 240;
-  final TeamFavoriteChangeCallback onTeamFavoriteChange;
 
-  const DashboardClubTeams({@required this.club, this.onTeamFavoriteChange, this.onTeamsLoaded});
+  const DashboardClubTeams({Key key, this.club, this.onTeamsChange}) : super(key: key);
 
   @override
   _DashboardClubTeamsState createState() => _DashboardClubTeamsState();
@@ -48,25 +47,15 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
     );
     _clubTeamsBloc.listen((state) {
       if (state is ClubTeamsLoaded) {
-        widget.onTeamsLoaded(state.teams);
+        widget.onTeamsChange(state.teams);
         if (_pageController.hasClients) {
           _currentIndex = 0;
           _pageController.jumpTo(0);
         }
       }
     });
-    _loadFavoriteTeams();
-    super.initState();
-  }
-
-  @override
-  void didUpdateWidget(DashboardClubTeams oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.club.code != widget.club.code) _loadFavoriteTeams();
-  }
-
-  void _loadFavoriteTeams() {
     _clubTeamsBloc.add(ClubFavoriteTeamsLoadEvent(widget.club.code));
+    super.initState();
   }
 
   @override
@@ -91,7 +80,7 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
                             currentlyDisplayed: _currentIndex == index,
                             team: state.teams[index],
                             distance: _currentTeamPage - index,
-                            onFavoriteChange: () => widget.onTeamFavoriteChange(state.teams[index]),
+                            onFavoriteChange: () => widget.onTeamsChange(null),
                           ),
                         );
                       },
@@ -101,7 +90,7 @@ class _DashboardClubTeamsState extends State<DashboardClubTeams> with SingleTick
                         padding: const EdgeInsets.all(28.0),
                         child: RaisedButton(
                           onPressed: () =>  Router.push(context: context, builder: (_) => ClubDetailPage(widget.club)).then(
-                            (_) => widget.onTeamFavoriteChange(null),
+                            (_) => widget.onTeamsChange(null),
                           ),
                           padding: EdgeInsets.all(12.0),
                           child: Text(

--- a/lib/pages/dashboard/widgets/team_card.dart
+++ b/lib/pages/dashboard/widgets/team_card.dart
@@ -85,7 +85,7 @@ class _TeamCardState extends State<TeamCard> {
   Function _onTap(TeamClassificationState state) {
     if (state is TeamClassificationLoadedState) {
       return () => Router.push(context: context, builder: (_) => TeamDetailPage(team: widget.team, classifications: state.classifications)).then(
-        (_) => widget.onFavoriteChange
+        (_) => widget.onFavoriteChange()
       );
     }
     else return null;

--- a/lib/repositories/providers/agenda_provider.dart
+++ b/lib/repositories/providers/agenda_provider.dart
@@ -1,5 +1,3 @@
-
-
 import 'package:dio/dio.dart';
 import 'package:dio_http_cache/dio_http_cache.dart';
 import 'package:intl/intl.dart';
@@ -29,8 +27,8 @@ class AgendaProvider {
   }
 
   Future<List<Event>> listTeamMonthEvents(String teamCode) async {
-    DateTime min = DateTime.now(), max = DateTime.now().add(Duration(days: 30));
-    DateFormat format = DateFormat("yyyy-MM-ddThh:mm:ss");
+    DateTime min = DateTime.now(), max = min.add(Duration(days: 30));
+    DateFormat format = DateFormat("yyyy-MM-ddTHH:00:00");
     Response response = await dio.get("/calendars?equipe=$teamCode&min=${format.format(min)}&max=${format.format(max)}", options: buildConfigurableCacheOptions());
     if (response.statusCode == 200) {
       return (response.data as List).map((json) => Event.fromJson(json)).toList();

--- a/lib/repositories/providers/agenda_provider.dart
+++ b/lib/repositories/providers/agenda_provider.dart
@@ -16,11 +16,9 @@ class AgendaProvider {
   }
 
   Future<List<Event>> listTeamMonthMatches(String teamCode) async {
-    Response response = await dio.get("/equipes/$teamCode/matchs", options: buildConfigurableCacheOptions());
+    Response response = await dio.get("/equipes/$teamCode/matchs?filter=weeks&value=4", options: buildConfigurableCacheOptions());
     if (response.statusCode == 200) {
-      List<Event> events = (response.data as List).map((json) => Event.fromJson(json)).toList();
-      events.removeWhere((event) => event.date.compareTo(DateTime.now()) < 0 || event.date.compareTo(DateTime.now().add(Duration(days: 30))) > 0);
-      return events;
+      return (response.data as List).map((json) => Event.fromJson(json)).toList();
     } else {
       throw Exception('Impossible de récupérer les événements');
     }

--- a/lib/repositories/providers/agenda_provider.dart
+++ b/lib/repositories/providers/agenda_provider.dart
@@ -2,6 +2,7 @@
 
 import 'package:dio/dio.dart';
 import 'package:dio_http_cache/dio_http_cache.dart';
+import 'package:intl/intl.dart';
 import 'package:v34/models/event.dart';
 import 'package:v34/repositories/providers/http.dart';
 
@@ -12,7 +13,30 @@ class AgendaProvider {
     if (response.statusCode == 200) {
       return (response.data as List).map((json) => Event.fromJson(json)).toList();
     } else {
-      throw Exception('Impossible de récupérer les clubs');
+      throw Exception('Impossible de récupérer les événements');
     }
   }
+
+  Future<List<Event>> listTeamMonthMatches(String teamCode) async {
+    Response response = await dio.get("/equipes/$teamCode/matchs", options: buildConfigurableCacheOptions());
+    if (response.statusCode == 200) {
+      List<Event> events = (response.data as List).map((json) => Event.fromJson(json)).toList();
+      events.removeWhere((event) => event.date.compareTo(DateTime.now()) < 0 || event.date.compareTo(DateTime.now().add(Duration(days: 30))) > 0);
+      return events;
+    } else {
+      throw Exception('Impossible de récupérer les événements');
+    }
+  }
+
+  Future<List<Event>> listTeamMonthEvents(String teamCode) async {
+    DateTime min = DateTime.now(), max = DateTime.now().add(Duration(days: 30));
+    DateFormat format = DateFormat("yyyy-MM-ddThh:mm:ss");
+    Response response = await dio.get("/calendars?equipe=$teamCode&min=${format.format(min)}&max=${format.format(max)}", options: buildConfigurableCacheOptions());
+    if (response.statusCode == 200) {
+      return (response.data as List).map((json) => Event.fromJson(json)).toList();
+    } else {
+      throw Exception('Impossible de récupérer les événements');
+    }
+  }
+
 }

--- a/lib/repositories/repository.dart
+++ b/lib/repositories/repository.dart
@@ -99,6 +99,13 @@ class Repository {
     return _agendaProvider.listEvents();
   }
 
+  Future<List<Event>> loadTeamMonthAgenda(String teamCode) async {
+    List<Event> matches = await _agendaProvider.listTeamMonthMatches(teamCode);
+    List<Event> events = await _agendaProvider.listTeamMonthEvents(teamCode);
+    events.addAll(matches);
+    return events;
+  }
+
   /// Update a favorite by providing the [FavoriteType], a generic favoriteId and the flag (favorite or not)
   Future updateFavorite(String favoriteId, FavoriteType favoriteType, bool favorite) async {
     switch (favoriteType) {


### PR DESCRIPTION
Close #39 

The dashboard agenda is now displaying the future team events (including matches).

- Add a handled event to AgendaBloc.
- Uses new requests in the agenda provider to fetch the calendar data.
- Increases agenda loading height on the dashboard to be well seen.

- Note: fetching (deal with?) calendar data is very slow. The consequence is a too long loading for the user.