### PR TITLE
Fix competition results

### DIFF
--- a/lib/commons/competition_badge.dart
+++ b/lib/commons/competition_badge.dart
@@ -10,51 +10,66 @@ class CompetitionBadge extends StatelessWidget {
 
   _CompetitionBadgePainter _drawCompetitionBadge(BuildContext context) {
     String gameType = competitionCode.substring(competitionCode.length - 1);
+    TextStyle subTitleStyle = Theme.of(context).textTheme.bodyText1;
     switch (int.parse(gameType)) {
       case 1:
         return _CompetitionBadgePainter(
             context: context,
             label: "4",
             leftColor: Colors.blue,
-            rightColor: Colors.blue);
+            rightColor: Colors.blue,
+            subtitleStyle: subTitleStyle,
+            subtitle: "4x4 masculin");
       case 2:
         return _CompetitionBadgePainter(
             context: context,
             label: "6",
             leftColor: Colors.blue,
-            rightColor: Colors.blue);
+            rightColor: Colors.blue,
+            subtitleStyle: subTitleStyle,
+            subtitle: "6x6 masculin");
       case 3:
       case 4:
         return _CompetitionBadgePainter(
             context: context,
             label: "4",
             leftColor: Colors.blue,
-            rightColor: Colors.pinkAccent);
+            rightColor: Colors.pinkAccent,
+            subtitleStyle: subTitleStyle,
+            subtitle: "4x4 mixte");
       case 5:
         return _CompetitionBadgePainter(
             context: context,
             label: "6",
             leftColor: Colors.blue,
-            rightColor: Colors.pinkAccent);
+            rightColor: Colors.pinkAccent,
+            subtitleStyle: subTitleStyle,
+            subtitle: "6x6 mixte");
       case 6:
         return _CompetitionBadgePainter(
             context: context,
             label: "4",
             leftColor: Colors.pinkAccent,
-            rightColor: Colors.pinkAccent);
+            rightColor: Colors.pinkAccent,
+            subtitleStyle: subTitleStyle,
+            subtitle: "4x4 féminin");
       case 7:
         return _CompetitionBadgePainter(
             context: context,
             label: "6",
             leftColor: Colors.pinkAccent,
-            rightColor: Colors.pinkAccent);
+            rightColor: Colors.pinkAccent,
+            subtitleStyle: subTitleStyle,
+            subtitle: "6x6 féminin");
       default:
         // throw new Exception("Type de compétition inconnue.");
         return _CompetitionBadgePainter(
             context: context,
-            label: "4",
+            label: "?",
             leftColor: Colors.blue,
-            rightColor: Colors.blue);
+            rightColor: Colors.blue,
+            subtitleStyle: subTitleStyle,
+            subtitle: "inconnu");
     }
   }
 
@@ -73,11 +88,15 @@ class _CompetitionBadgePainter extends CustomPainter {
   final String label;
   final Color leftColor;
   final Color rightColor;
+  final String subtitle;
+  final TextStyle subtitleStyle;
 
   _CompetitionBadgePainter(
       {@required this.context,
       @required this.label,
       @required this.leftColor,
+      @required this.subtitle,
+      @required this.subtitleStyle,
       Color rightColor})
       : this.rightColor = rightColor ?? leftColor;
 
@@ -111,7 +130,6 @@ class _CompetitionBadgePainter extends CustomPainter {
         Offset(demiHeight, demiHeight), Offset(demiHeight, demiHeight), left);
     canvas.drawLine(
         Offset(demiHeight, demiHeight), Offset(height, demiHeight), leftSquare);
-
     canvas.drawLine(Offset(width - demiHeight, demiHeight),
         Offset(width - demiHeight, demiHeight), right);
     canvas.drawLine(Offset(width - demiHeight, demiHeight),
@@ -123,13 +141,22 @@ class _CompetitionBadgePainter extends CustomPainter {
         text: span,
         textAlign: TextAlign.left,
         textDirection: TextDirection.ltr);
-
     tp.layout();
-
     tp.paint(
         canvas, Offset(demiHeight - tp.width / 2, demiHeight - tp.height / 2));
     tp.paint(canvas,
         Offset(width - demiHeight - tp.width / 2, demiHeight - tp.height / 2));
+
+    TextSpan subtitleSpan = TextSpan(text: subtitle, style: subtitleStyle);
+    TextPainter subtitleTp = TextPainter(
+        text: subtitleSpan,
+        textAlign: TextAlign.left,
+        textDirection: TextDirection.ltr);
+    subtitleTp.layout();
+    subtitleTp.paint(
+        canvas,
+        Offset(size.width / 2 - subtitleTp.width / 2,
+            height + subtitleTp.height / 4));
   }
 
   @override

--- a/lib/commons/competition_badge.dart
+++ b/lib/commons/competition_badge.dart
@@ -4,27 +4,57 @@ class CompetitionBadge extends StatelessWidget {
   final double deltaSize;
   final String competitionCode;
 
-  const CompetitionBadge({Key key, this.deltaSize = 1, @required this.competitionCode}) : super(key: key);
+  const CompetitionBadge(
+      {Key key, this.deltaSize = 1, @required this.competitionCode})
+      : super(key: key);
 
   _CompetitionBadgePainter _drawCompetitionBadge(BuildContext context) {
     String gameType = competitionCode.substring(competitionCode.length - 1);
     switch (int.parse(gameType)) {
       case 1:
-        return _CompetitionBadgePainter(context: context, label: "4", leftColor: Colors.blue, rightColor: Colors.blue);
+        return _CompetitionBadgePainter(
+            context: context,
+            label: "4",
+            leftColor: Colors.blue,
+            rightColor: Colors.blue);
       case 2:
-        return _CompetitionBadgePainter(context: context, label: "6", leftColor: Colors.blue, rightColor: Colors.blue);
+        return _CompetitionBadgePainter(
+            context: context,
+            label: "6",
+            leftColor: Colors.blue,
+            rightColor: Colors.blue);
       case 3:
       case 4:
-        return _CompetitionBadgePainter(context: context, label: "4", leftColor: Colors.blue, rightColor: Colors.pinkAccent);
+        return _CompetitionBadgePainter(
+            context: context,
+            label: "4",
+            leftColor: Colors.blue,
+            rightColor: Colors.pinkAccent);
       case 5:
-        return _CompetitionBadgePainter(context: context, label: "6", leftColor: Colors.blue, rightColor: Colors.pinkAccent);
+        return _CompetitionBadgePainter(
+            context: context,
+            label: "6",
+            leftColor: Colors.blue,
+            rightColor: Colors.pinkAccent);
       case 6:
-        return _CompetitionBadgePainter(context: context, label: "4", leftColor: Colors.pinkAccent, rightColor: Colors.pinkAccent);
+        return _CompetitionBadgePainter(
+            context: context,
+            label: "4",
+            leftColor: Colors.pinkAccent,
+            rightColor: Colors.pinkAccent);
       case 7:
-        return _CompetitionBadgePainter(context: context, label: "6", leftColor: Colors.pinkAccent, rightColor: Colors.pinkAccent);
+        return _CompetitionBadgePainter(
+            context: context,
+            label: "6",
+            leftColor: Colors.pinkAccent,
+            rightColor: Colors.pinkAccent);
       default:
         // throw new Exception("Type de compétition inconnue.");
-        return _CompetitionBadgePainter(context: context, label: "4", leftColor: Colors.blue, rightColor: Colors.blue);
+        return _CompetitionBadgePainter(
+            context: context,
+            label: "4",
+            leftColor: Colors.blue,
+            rightColor: Colors.blue);
     }
   }
 
@@ -39,17 +69,20 @@ class CompetitionBadge extends StatelessWidget {
 }
 
 class _CompetitionBadgePainter extends CustomPainter {
-
   final BuildContext context;
   final String label;
   final Color leftColor;
   final Color rightColor;
 
-  _CompetitionBadgePainter({@required this.context, @required this.label, @required this.leftColor, Color rightColor}) : this.rightColor = rightColor ?? leftColor;
+  _CompetitionBadgePainter(
+      {@required this.context,
+      @required this.label,
+      @required this.leftColor,
+      Color rightColor})
+      : this.rightColor = rightColor ?? leftColor;
 
   @override
   void paint(Canvas canvas, Size size) {
-
     double width = size.width;
     double height = size.height, demiHeight = height / 2;
 
@@ -74,20 +107,29 @@ class _CompetitionBadgePainter extends CustomPainter {
       ..style = PaintingStyle.fill
       ..strokeWidth = height;
 
-    canvas.drawLine(Offset(demiHeight, demiHeight), Offset(demiHeight, demiHeight), left);
-    canvas.drawLine(Offset(demiHeight, demiHeight), Offset(height, demiHeight), leftSquare);
+    canvas.drawLine(
+        Offset(demiHeight, demiHeight), Offset(demiHeight, demiHeight), left);
+    canvas.drawLine(
+        Offset(demiHeight, demiHeight), Offset(height, demiHeight), leftSquare);
 
-    canvas.drawLine(Offset(width - demiHeight, demiHeight), Offset(width - demiHeight, demiHeight), right);
-    canvas.drawLine(Offset(width - demiHeight, demiHeight), Offset(width - height, demiHeight), rightSquare);
+    canvas.drawLine(Offset(width - demiHeight, demiHeight),
+        Offset(width - demiHeight, demiHeight), right);
+    canvas.drawLine(Offset(width - demiHeight, demiHeight),
+        Offset(width - height, demiHeight), rightSquare);
 
-    TextStyle textStyle = TextStyle(color: Theme.of(context).textTheme.bodyText2.color, fontSize: 18);
+    TextStyle textStyle = TextStyle(color: Colors.white, fontSize: 18);
     TextSpan span = TextSpan(text: label, style: textStyle);
-    TextPainter tp = TextPainter(text: span, textAlign: TextAlign.left, textDirection: TextDirection.ltr);
+    TextPainter tp = TextPainter(
+        text: span,
+        textAlign: TextAlign.left,
+        textDirection: TextDirection.ltr);
 
     tp.layout();
 
-    tp.paint(canvas, Offset(demiHeight - tp.width / 2, demiHeight - tp.height / 2));
-    tp.paint(canvas, Offset(width - demiHeight - tp.width / 2, demiHeight - tp.height / 2));
+    tp.paint(
+        canvas, Offset(demiHeight - tp.width / 2, demiHeight - tp.height / 2));
+    tp.paint(canvas,
+        Offset(width - demiHeight - tp.width / 2, demiHeight - tp.height / 2));
   }
 
   @override

--- a/lib/commons/paragraph.dart
+++ b/lib/commons/paragraph.dart
@@ -1,25 +1,47 @@
-
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class Paragraph extends StatelessWidget {
-
   final String title;
   final Widget child;
   final double topPadding;
   final double bottomPadding;
 
-  Paragraph({this.title, this.child, this.topPadding = 20.0, this.bottomPadding = 0.0});
+  Paragraph(
+      {this.title,
+      this.child,
+      this.topPadding = 40.0,
+      this.bottomPadding = 0.0});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(left: 18.0, right: 8.0, top: topPadding, bottom: bottomPadding),
+      padding: EdgeInsets.only(
+          left: 18.0, right: 8.0, top: topPadding, bottom: bottomPadding),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Text(title, style: Theme.of(context).textTheme.headline6),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                  flex: 1,
+                  child: Divider(
+                      color: Theme.of(context).textTheme.headline6.color)),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child:
+                    Text(title, style: Theme.of(context).textTheme.headline6),
+              ),
+              Expanded(
+                  flex: 8,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 8.0),
+                    child: Divider(
+                        color: Theme.of(context).textTheme.headline6.color),
+                  )),
+            ],
+          ),
           child ?? SizedBox(),
         ],
       ),

--- a/lib/commons/podium.dart
+++ b/lib/commons/podium.dart
@@ -25,14 +25,18 @@ class Podium extends StatefulWidget {
   final int promoted;
   final int relegated;
 
-  Podium(this.placeValues, {this.title = "", this.active = true, this.highlightedIndex, this.promoted = 0, this.relegated = 0});
+  Podium(this.placeValues,
+      {this.title = "",
+      this.active = true,
+      this.highlightedIndex,
+      this.promoted = 0,
+      this.relegated = 0});
 
   @override
   _PodiumState createState() => _PodiumState();
 }
 
 class _PodiumState extends State<Podium> {
-
   List<Place> places;
   PlaceValue max;
   List<PlaceValue> placeValues;
@@ -45,7 +49,8 @@ class _PodiumState extends State<Podium> {
   @override
   void initState() {
     _updatePlaces();
-    places = List.generate(placeValues.length, (index) => Place(PlaceValue("", 0), "", false));
+    places = List.generate(
+        placeValues.length, (index) => Place(PlaceValue("", 0), "", false));
     super.initState();
   }
 
@@ -58,22 +63,27 @@ class _PodiumState extends State<Podium> {
   _updatePlaces() {
     placeValues = widget.placeValues;
     highlightedValue = placeValues[widget.highlightedIndex];
-    max = placeValues.fold(new PlaceValue("", 0), (max, placeValue) => placeValue.value > max.value ? placeValue : max);
+    max = placeValues.fold(new PlaceValue("", 0),
+        (max, placeValue) => placeValue.value > max.value ? placeValue : max);
     if (widget.active) {
       Future.delayed(Duration(milliseconds: 200), () {
         var length = placeValues.length;
         if (this.mounted) {
           setState(() {
             places = List.generate(length, (index) {
-              var diff = (placeValues[index].value - highlightedValue.value).round();
-              var diffStr = ((index > 0 && placeValues[index - 1].id == highlightedValue.id) ||
-                  (index < placeValues.length - 1 && placeValues[index + 1].id == highlightedValue.id))
+              var diff =
+                  (placeValues[index].value - highlightedValue.value).round();
+              var diffStr = ((index > 0 &&
+                          placeValues[index - 1].id == highlightedValue.id) ||
+                      (index < placeValues.length - 1 &&
+                          placeValues[index + 1].id == highlightedValue.id))
                   ? (diff > 0 ? "+$diff" : "$diff")
                   : "";
               if (placeValues[index].id == highlightedValue.id) {
                 position = placeValues.length - index;
               }
-              return Place(placeValues[index], "$diffStr", placeValues[index].id == highlightedValue.id);
+              return Place(placeValues[index], "$diffStr",
+                  placeValues[index].id == highlightedValue.id);
             });
             Future.delayed(Duration(milliseconds: animationDuration + 0), () {
               if (this.mounted) {
@@ -97,7 +107,8 @@ class _PodiumState extends State<Podium> {
         showToolTip = false;
         showPosition = false;
         position = null;
-        places = List.generate(placeValues.length, (index) => Place(PlaceValue("", 0), "", false));
+        places = List.generate(
+            placeValues.length, (index) => Place(PlaceValue("", 0), "", false));
       });
     }
   }
@@ -120,7 +131,9 @@ class _PodiumState extends State<Podium> {
                       fontFamily: "Roboto",
                       fontSize: 108,
                       fontWeight: FontWeight.w500,
-                      color: _getColor(placeValues.length - position, context).tiny(5).withAlpha(70),
+                      color: _getColor(placeValues.length - position, context)
+                          .tiny(5)
+                          .withAlpha(70),
                     ),
                   ),
                 )
@@ -128,35 +141,42 @@ class _PodiumState extends State<Podium> {
         ),
         Positioned(
           top: 10,
-          left: position == 1 ? 57 : (position == 4 || position == 6 ? 65 : (position == 7 ? 74 : 70)),
+          left: position == 1
+              ? 57
+              : (position == 4 || position == 6
+                  ? 65
+                  : (position == 7 ? 74 : 70)),
           child: position != null && placeValues != null
               ? AnimatedOpacity(
-            duration: Duration(milliseconds: 2000),
-            curve: Curves.easeInOut,
-            opacity: showPosition ? 1.0 : 0.0,
-            child: Text(
-              position == 1 ? "er" : "ème",
-              style: TextStyle(
-                fontFamily: "Roboto",
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-                color: _getColor(placeValues.length - position, context).withAlpha(200),
-              ),
-            ),
-          )
+                  duration: Duration(milliseconds: 2000),
+                  curve: Curves.easeInOut,
+                  opacity: showPosition ? 1.0 : 0.0,
+                  child: Text(
+                    position == 1 ? "er" : "ème",
+                    style: TextStyle(
+                      fontFamily: "Roboto",
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                      color: _getColor(placeValues.length - position, context)
+                          .withAlpha(200),
+                    ),
+                  ),
+                )
               : Text(""),
         ),
         Align(
           alignment: Alignment.center,
           child: Padding(
-            padding: const EdgeInsets.only(left: 8.0, right: 8.0, top: 38.0, bottom: 10),
+            padding: const EdgeInsets.only(
+                left: 8.0, right: 8.0, top: 38.0, bottom: 0),
             child: Container(
               child: Column(
                 children: <Widget>[
                   Expanded(child: _buildBarChart(context)),
                   Padding(
                     padding: const EdgeInsets.only(top: 8.0),
-                    child: Text(widget.title),
+                    child: Text(widget.title,
+                        style: Theme.of(context).textTheme.bodyText1),
                   ),
                 ],
               ),
@@ -183,7 +203,9 @@ class _PodiumState extends State<Podium> {
                 BarChartRodData(
                   y: entry.value.placeValue.value,
                   width: 9,
-                  color: entry.value.highlight ? _getColor(entry.key, context) : Theme.of(context).cardTheme.color.tiny(10),
+                  color: entry.value.highlight
+                      ? _getColor(entry.key, context)
+                      : Theme.of(context).cardTheme.color.tiny(10),
                   backDrawRodData: BackgroundBarChartRodData(
                     show: false,
                     y: max.value,
@@ -211,7 +233,10 @@ class _PodiumState extends State<Podium> {
             ) {
               return BarTooltipItem(
                 showToolTip ? places[groupIndex].tooltip : "",
-                TextStyle(color: Theme.of(context).textTheme.bodyText1.color, fontSize: 10, fontFamily: "Raleway"),
+                TextStyle(
+                    color: Theme.of(context).textTheme.bodyText1.color,
+                    fontSize: 10,
+                    fontFamily: "Raleway"),
               );
             },
           ),
@@ -223,7 +248,8 @@ class _PodiumState extends State<Podium> {
 
   Color _getColor(int placeIndex, BuildContext context) {
     var podiumLength = placeValues.length;
-    if (placeIndex >= podiumLength - widget.promoted) return Colors.lightGreenAccent;
+    if (placeIndex >= podiumLength - widget.promoted)
+      return Colors.lightGreenAccent;
     if (placeIndex <= widget.relegated) return Colors.deepOrangeAccent;
     return Colors.blueAccent;
   }

--- a/lib/models/classication.dart
+++ b/lib/models/classication.dart
@@ -1,4 +1,5 @@
 class ClassificationTeamSynthesis {
+  final String name;
   final String teamCode;
   final int rank, totalPoints;
   final int wonMatches, lostMatches;
@@ -9,19 +10,45 @@ class ClassificationTeamSynthesis {
   final int nbSetsMI;
 
   ClassificationTeamSynthesis(
-    this.teamCode, this.rank, this.totalPoints, this.wonMatches, this.lostMatches,
-    this.wonSets, this.lostSets, this.wonPoints, this.lostPoints, this.nbSets30,
-    this.nbSets31, this.nbSets32, this.nbSets03, this.nbSets13, this.nbSets23, this.nbSetsMI,
+    this.name,
+    this.teamCode,
+    this.rank,
+    this.totalPoints,
+    this.wonMatches,
+    this.lostMatches,
+    this.wonSets,
+    this.lostSets,
+    this.wonPoints,
+    this.lostPoints,
+    this.nbSets30,
+    this.nbSets31,
+    this.nbSets32,
+    this.nbSets03,
+    this.nbSets13,
+    this.nbSets23,
+    this.nbSetsMI,
   );
 
   factory ClassificationTeamSynthesis.fromJson(Map<String, dynamic> json) {
     return ClassificationTeamSynthesis(
-      json["EquipeCode"], json["Rang"], json["Total"], json["Gagne"], json["Perdu"],
-      json["SetP"], json["SetC"], json["PointsP"], json["PointsC"], json["NbSets_30"],
-      json["NbSets_31"], json["NbSets_32"], json["NbSets_03"], json["NbSets_13"], json["NbSets_23"], json["NbSets_MI"]
-    );
+        json["Nom"],
+        json["EquipeCode"],
+        json["Rang"],
+        json["Total"],
+        json["Gagne"],
+        json["Perdu"],
+        json["SetP"],
+        json["SetC"],
+        json["PointsP"],
+        json["PointsC"],
+        json["NbSets_30"],
+        json["NbSets_31"],
+        json["NbSets_32"],
+        json["NbSets_03"],
+        json["NbSets_13"],
+        json["NbSets_23"],
+        json["NbSets_MI"]);
   }
-
 }
 
 class ClassificationSynthesis {
@@ -34,7 +61,15 @@ class ClassificationSynthesis {
   final String pool;
   final List<ClassificationTeamSynthesis> teamsClassifications;
 
-  ClassificationSynthesis(this.competitionCode, this.label, this.fullLabel, this.promoted, this.relegated, this.division, this.pool, this.teamsClassifications);
+  ClassificationSynthesis(
+      this.competitionCode,
+      this.label,
+      this.fullLabel,
+      this.promoted,
+      this.relegated,
+      this.division,
+      this.pool,
+      this.teamsClassifications);
 
   factory ClassificationSynthesis.fromJson(Map<String, dynamic> json) {
     return ClassificationSynthesis(
@@ -45,12 +80,14 @@ class ClassificationSynthesis {
       json["Relegue"],
       json["Division"],
       json["Poule"],
-      (json["classementDetail"] as List<dynamic>).map((detail) => ClassificationTeamSynthesis.fromJson(detail)).toList(),
+      (json["classementDetail"] as List<dynamic>)
+          .map((detail) => ClassificationTeamSynthesis.fromJson(detail))
+          .toList(),
     );
   }
 
   static String _getLabel(String label) {
-    var extractedLabel  = label.split(" ")[0];
+    var extractedLabel = label.split(" ")[0];
     return extractedLabel;
   }
 }

--- a/lib/pages/dashboard/widgets/team_card.dart
+++ b/lib/pages/dashboard/widgets/team_card.dart
@@ -99,7 +99,7 @@ class _TeamCardState extends State<TeamCard> {
   @override
   Widget build(BuildContext context) {
     var absDistance = widget.distance.abs() > 1 ? 1 : widget.distance.abs();
-    final double cardBodyHeight = widget.cardHeight - 20;
+    final double cardBodyHeight = widget.cardHeight - 30;
     return BlocBuilder<TeamClassificationBloc, TeamClassificationState>(
       cubit: _classificationBloc,
       builder: (context, state) {
@@ -108,9 +108,12 @@ class _TeamCardState extends State<TeamCard> {
           child: TitledCard(
             title: widget.team.name,
             bodyPadding: EdgeInsets.zero,
-            body: Container(
-              height: cardBodyHeight,
-              child: Row(children: _getPodiumWidget(state)),
+            body: Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+              child: Container(
+                height: cardBodyHeight,
+                child: Row(children: _getPodiumWidget(state)),
+              ),
             ),
             onTap: _onTap(state),
           ),

--- a/lib/pages/team-details/ranking/statistics_widget.dart
+++ b/lib/pages/team-details/ranking/statistics_widget.dart
@@ -5,10 +5,17 @@ class StatisticsWidget extends StatelessWidget {
   final String title;
   final int wonPoints;
   final int lostPoints;
+  final int maxPoints;
 
   static final double miniGraphSize = 60;
 
-  const StatisticsWidget({Key key, @required this.wonPoints, @required this.lostPoints, @required this.title}) : super(key: key);
+  const StatisticsWidget(
+      {Key key,
+      @required this.wonPoints,
+      @required this.lostPoints,
+      @required this.title,
+      @required this.maxPoints})
+      : super(key: key);
 
   Widget _buildRatio(BuildContext context) {
     return RichText(
@@ -22,7 +29,9 @@ class StatisticsWidget extends StatelessWidget {
           color: Theme.of(context).textTheme.bodyText2.color,
         ),
         children: <TextSpan>[
-          new TextSpan(text: ' / ${wonPoints + lostPoints}', style: TextStyle(fontSize: 12, fontWeight: FontWeight.normal)),
+          new TextSpan(
+              text: ' / ${(maxPoints ?? lostPoints)}',
+              style: TextStyle(fontSize: 12, fontWeight: FontWeight.normal)),
         ],
       ),
     );
@@ -34,7 +43,7 @@ class StatisticsWidget extends StatelessWidget {
       width: miniGraphSize,
       child: ArcGraph(
         minValue: 0,
-        maxValue: (wonPoints + lostPoints).toDouble(),
+        maxValue: (maxPoints ?? lostPoints).toDouble(),
         value: wonPoints.toDouble(),
         lineWidth: 6,
         leftTitle: LeftTitle(
@@ -43,7 +52,9 @@ class StatisticsWidget extends StatelessWidget {
           style: Theme.of(context).textTheme.bodyText1,
         ),
         valueBuilder: (value, minValue, maxValue) {
-          var percentage = maxValue != 0 ? "${(((value - minValue) / maxValue) * 100).toStringAsFixed(1)}%" : "- -";
+          var percentage = maxValue != 0
+              ? "${(((value - minValue) / maxValue) * 100).toStringAsFixed(1)}%"
+              : "- -";
           return Text(percentage);
         },
       ),
@@ -56,7 +67,10 @@ class StatisticsWidget extends StatelessWidget {
       padding: EdgeInsets.symmetric(vertical: 20.0),
       child: Row(
         children: <Widget>[
-          Expanded(child: Text(title, textAlign: TextAlign.center, style: Theme.of(context).textTheme.bodyText1)),
+          Expanded(
+              child: Text(title,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyText1)),
           Expanded(child: _buildRatio(context)),
           Expanded(child: _buildGraph(context)),
         ],

--- a/lib/pages/team-details/ranking/statistics_widget.dart
+++ b/lib/pages/team-details/ranking/statistics_widget.dart
@@ -12,7 +12,7 @@ class StatisticsWidget extends StatelessWidget {
   const StatisticsWidget(
       {Key key,
       @required this.wonPoints,
-      @required this.lostPoints,
+      this.lostPoints,
       @required this.title,
       @required this.maxPoints})
       : super(key: key);

--- a/lib/pages/team-details/ranking/summary_widget.dart
+++ b/lib/pages/team-details/ranking/summary_widget.dart
@@ -9,40 +9,56 @@ class SummaryWidget extends StatelessWidget {
 
   static final double miniGraphHeight = 100;
 
-  const SummaryWidget({Key key, @required this.title, @required this.teamStats}) : super(key: key);
+  const SummaryWidget({Key key, @required this.title, @required this.teamStats})
+      : super(key: key);
 
-  List<BarChartGroupData> showingGroups(BuildContext context, ClassificationTeamSynthesis teamStats) {
+  List<BarChartGroupData> showingGroups(
+      BuildContext context, ClassificationTeamSynthesis teamStats) {
     return List.generate(7, (i) {
       switch (i) {
         case 0:
-          return makeGroupData(context, 0, teamStats.nbSets30.toDouble(), Colors.green, teamStats);
+          return makeGroupData(context, 0, teamStats.nbSets30.toDouble(),
+              Colors.green, teamStats);
         case 1:
-          return makeGroupData(context, 1, teamStats.nbSets31.toDouble(), Colors.greenAccent, teamStats);
+          return makeGroupData(context, 1, teamStats.nbSets31.toDouble(),
+              Colors.greenAccent, teamStats);
         case 2:
-          return makeGroupData(context, 2, teamStats.nbSets32.toDouble(), Colors.yellowAccent, teamStats);
+          return makeGroupData(context, 2, teamStats.nbSets32.toDouble(),
+              Colors.yellowAccent, teamStats);
         case 3:
-          return makeGroupData(context, 3, teamStats.nbSets23.toDouble(), Colors.orangeAccent, teamStats);
+          return makeGroupData(context, 3, teamStats.nbSets23.toDouble(),
+              Colors.orangeAccent, teamStats);
         case 4:
-          return makeGroupData(context, 4, teamStats.nbSets13.toDouble(), Colors.deepOrangeAccent, teamStats);
+          return makeGroupData(context, 4, teamStats.nbSets13.toDouble(),
+              Colors.deepOrangeAccent, teamStats);
         case 5:
-          return makeGroupData(context, 5, teamStats.nbSets03.toDouble(), Colors.redAccent, teamStats);
+          return makeGroupData(context, 5, teamStats.nbSets03.toDouble(),
+              Colors.redAccent, teamStats);
         case 6:
-          return makeGroupData(context, 6, teamStats.nbSetsMI.toDouble(), Theme.of(context).accentColor, teamStats);
+          return makeGroupData(context, 6, teamStats.nbSetsMI.toDouble(),
+              Theme.of(context).accentColor, teamStats);
         default:
           return null;
       }
     });
   }
 
-  BarChartGroupData makeGroupData(BuildContext context, int x, double y, Color barColor, ClassificationTeamSynthesis teamStats) {
+  BarChartGroupData makeGroupData(BuildContext context, int x, double y,
+      Color barColor, ClassificationTeamSynthesis teamStats) {
     return BarChartGroupData(
       x: x,
       barRods: [
-        BarChartRodData(y: y, color: barColor, width: 12,
+        BarChartRodData(
+          y: y,
+          color: barColor,
+          width: 12,
           backDrawRodData: BackgroundBarChartRodData(
             show: true,
             y: (teamStats.wonMatches + teamStats.lostMatches).toDouble(),
-            color: Theme.of(context).cardTheme.color.tiny(10), //barBackgroundColor,
+            color: Theme.of(context)
+                .cardTheme
+                .color
+                .tiny(10), //barBackgroundColor,
           ),
         ),
       ],
@@ -65,31 +81,47 @@ class SummaryWidget extends StatelessWidget {
               textStyle: Theme.of(context).textTheme.bodyText2,
               getTitles: (double value) {
                 switch (value.toInt()) {
-                  case 0: return '${teamStats.nbSets30 > 0 ? teamStats.nbSets30.toString() : ""}';
-                  case 1: return '${teamStats.nbSets31 > 0 ? teamStats.nbSets31.toString() : ""}';
-                  case 2: return '${teamStats.nbSets32 > 0 ? teamStats.nbSets32.toString() : ""}';
-                  case 3: return '${teamStats.nbSets23 > 0 ? teamStats.nbSets23.toString() : ""}';
-                  case 4: return '${teamStats.nbSets13 > 0 ? teamStats.nbSets13.toString() : ""}';
-                  case 5: return '${teamStats.nbSets03 > 0 ? teamStats.nbSets03.toString() : ""}';
-                  case 6: return '${teamStats.nbSetsMI > 0 ? teamStats.nbSetsMI.toString() : ""}';
-                  default: return '';
+                  case 0:
+                    return '${teamStats.nbSets30 > 0 ? teamStats.nbSets30.toString() : ""}';
+                  case 1:
+                    return '${teamStats.nbSets31 > 0 ? teamStats.nbSets31.toString() : ""}';
+                  case 2:
+                    return '${teamStats.nbSets32 > 0 ? teamStats.nbSets32.toString() : ""}';
+                  case 3:
+                    return '${teamStats.nbSets23 > 0 ? teamStats.nbSets23.toString() : ""}';
+                  case 4:
+                    return '${teamStats.nbSets13 > 0 ? teamStats.nbSets13.toString() : ""}';
+                  case 5:
+                    return '${teamStats.nbSets03 > 0 ? teamStats.nbSets03.toString() : ""}';
+                  case 6:
+                    return '${teamStats.nbSetsMI > 0 ? teamStats.nbSetsMI.toString() : ""}';
+                  default:
+                    return '';
                 }
               },
             ),
             bottomTitles: SideTitles(
               showTitles: true,
-              textStyle: Theme.of(context).textTheme.bodyText2,
+              textStyle: Theme.of(context).textTheme.bodyText1,
               margin: 2,
               getTitles: (double value) {
                 switch (value.toInt()) {
-                  case 0: return '3-0';
-                  case 1: return '3-1';
-                  case 2: return '3-2';
-                  case 3: return '2-3';
-                  case 4: return '1-3';
-                  case 5: return '0-3';
-                  case 6: return 'NT';
-                  default: return '';
+                  case 0:
+                    return '3-0';
+                  case 1:
+                    return '3-1';
+                  case 2:
+                    return '3-2';
+                  case 3:
+                    return '2-3';
+                  case 4:
+                    return '1-3';
+                  case 5:
+                    return '0-3';
+                  case 6:
+                    return 'NT';
+                  default:
+                    return '';
                 }
               },
             ),
@@ -107,11 +139,14 @@ class SummaryWidget extends StatelessWidget {
       padding: EdgeInsets.symmetric(vertical: 20.0),
       child: Row(
         children: <Widget>[
-          Expanded(flex: 1, child: Text(title, textAlign: TextAlign.center, style: Theme.of(context).textTheme.bodyText1)),
+          Expanded(
+              flex: 1,
+              child: Text(title,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyText1)),
           Expanded(flex: 2, child: _buildGraph(context)),
         ],
       ),
     );
   }
-
 }

--- a/lib/pages/team-details/ranking/team_ranking.dart
+++ b/lib/pages/team-details/ranking/team_ranking.dart
@@ -8,7 +8,6 @@ import 'package:v34/models/classication.dart';
 import 'package:v34/models/match_result.dart';
 import 'package:v34/models/team.dart';
 import 'package:v34/pages/club-details/blocs/club_team.bloc.dart';
-import 'package:v34/pages/team-details/information_divider.dart';
 import 'package:v34/pages/team-details/ranking/statistics_widget.dart';
 import 'package:v34/pages/team-details/ranking/summary_widget.dart';
 
@@ -35,6 +34,7 @@ class _TeamRankingState extends State<TeamRanking> {
 
   @override
   void initState() {
+    super.initState();
     Future.delayed(Duration(milliseconds: 800), () {
       setState(() {
         _cupOpacity = 1;
@@ -106,41 +106,79 @@ class _TeamRankingState extends State<TeamRanking> {
     else if (widget.classification.teamsClassifications.length -
             teamStats.rank <
         widget.classification.relegated) title = "Reléguée";
-    return FractionallySizedBox(
-      widthFactor: 0.8,
-      child: Stack(
-        children: [
-          Container(
-            alignment: Alignment.bottomRight,
-            height: 50,
-            child: AnimatedOpacity(
-              opacity: _cupOpacity,
-              duration: Duration(milliseconds: 1800),
-              curve: Curves.easeInOut,
-              child: FaIcon(
-                FontAwesomeIcons.trophy,
-                size: 44,
-                color: _getRankColor(teamStats.rank),
+    return Column(
+      children: [
+        FractionallySizedBox(
+          widthFactor: 0.8,
+          child: Stack(
+            children: [
+              Container(
+                alignment: Alignment.bottomRight,
+                height: 50,
+                child: AnimatedOpacity(
+                  opacity: _cupOpacity,
+                  duration: Duration(milliseconds: 1800),
+                  curve: Curves.easeInOut,
+                  child: FaIcon(
+                    FontAwesomeIcons.trophy,
+                    size: 44,
+                    color: _getRankColor(teamStats.rank),
+                  ),
+                ),
               ),
-            ),
+              Container(
+                alignment: Alignment.bottomLeft,
+                height: 150,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Expanded(
+                        child: PodiumWidget(
+                            title: title,
+                            classification: widget.classification,
+                            currentlyDisplayed: true,
+                            highlightedTeamCode: widget.team.code)),
+                  ],
+                ),
+              ),
+            ],
           ),
-          Container(
-            alignment: Alignment.bottomLeft,
-            height: 150,
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Expanded(
-                    child: PodiumWidget(
-                        title: title,
-                        classification: widget.classification,
-                        currentlyDisplayed: true,
-                        highlightedTeamCode: widget.team.code)),
-              ],
-            ),
-          ),
-        ],
-      ),
+        ),
+        ...widget.classification.teamsClassifications.reversed
+            .map((classificationSynthesis) {
+          return Padding(
+            padding:
+                const EdgeInsets.only(left: 28.0, right: 28, top: 6, bottom: 6),
+            child: Container(
+                alignment: Alignment.centerLeft,
+                child: Row(
+                  children: [
+                    Expanded(
+                      flex: 5,
+                      child: Text(
+                        classificationSynthesis.name,
+                        overflow: TextOverflow.fade,
+                        maxLines: 1,
+                        style:
+                            classificationSynthesis.teamCode == widget.team.code
+                                ? Theme.of(context).textTheme.bodyText2
+                                : Theme.of(context).textTheme.bodyText1,
+                      ),
+                    ),
+                    Expanded(
+                        flex: 1,
+                        child: Text(
+                          "${classificationSynthesis.wonSets} pts",
+                          style: classificationSynthesis.teamCode ==
+                                  widget.team.code
+                              ? Theme.of(context).textTheme.bodyText2
+                              : Theme.of(context).textTheme.bodyText1,
+                        ))
+                  ],
+                )),
+          );
+        }).toList()
+      ],
     );
   }
 

--- a/lib/pages/team-details/ranking/team_ranking.dart
+++ b/lib/pages/team-details/ranking/team_ranking.dart
@@ -31,6 +31,7 @@ class TeamRanking extends StatefulWidget {
 
 class _TeamRankingState extends State<TeamRanking> {
   double _cupOpacity = 0;
+  bool _openClassificationList = false;
 
   @override
   void initState() {
@@ -144,40 +145,84 @@ class _TeamRankingState extends State<TeamRanking> {
             ],
           ),
         ),
-        ...widget.classification.teamsClassifications.reversed
-            .map((classificationSynthesis) {
-          return Padding(
-            padding:
-                const EdgeInsets.only(left: 28.0, right: 28, top: 6, bottom: 6),
-            child: Container(
-                alignment: Alignment.centerLeft,
-                child: Row(
+        Align(
+          child: GestureDetector(
+            onTap: () {
+              setState(() {
+                _openClassificationList = !_openClassificationList;
+              });
+            },
+            child: Padding(
+              padding: const EdgeInsets.only(right: 18.0, top: 12, bottom: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Text(
+                      _openClassificationList
+                          ? "Cacher le détail"
+                          : "Voir le détail",
+                      style: Theme.of(context).textTheme.bodyText2),
+                  Icon(
+                    _openClassificationList
+                        ? Icons.arrow_drop_up
+                        : Icons.arrow_drop_down,
+                    color: Theme.of(context).textTheme.bodyText2.color,
+                  )
+                ],
+              ),
+            ),
+          ),
+          alignment: Alignment.bottomRight,
+        ),
+        AnimatedOpacity(
+          curve: Curves.easeInOut,
+          duration: Duration(milliseconds: 800),
+          opacity: _openClassificationList ? 1.0 : 0.0,
+          child: _openClassificationList
+              ? Column(
                   children: [
-                    Expanded(
-                      flex: 5,
-                      child: Text(
-                        classificationSynthesis.name,
-                        overflow: TextOverflow.fade,
-                        maxLines: 1,
-                        style:
-                            classificationSynthesis.teamCode == widget.team.code
-                                ? Theme.of(context).textTheme.bodyText2
-                                : Theme.of(context).textTheme.bodyText1,
-                      ),
-                    ),
-                    Expanded(
-                        flex: 1,
-                        child: Text(
-                          "${classificationSynthesis.wonSets} pts",
-                          style: classificationSynthesis.teamCode ==
-                                  widget.team.code
-                              ? Theme.of(context).textTheme.bodyText2
-                              : Theme.of(context).textTheme.bodyText1,
-                        ))
+                    ...widget.classification.teamsClassifications.reversed
+                        .map((classificationSynthesis) {
+                      return Padding(
+                        padding: const EdgeInsets.only(
+                            left: 28.0, right: 28, top: 6, bottom: 6),
+                        child: Container(
+                            alignment: Alignment.centerLeft,
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  flex: 5,
+                                  child: Text(
+                                    classificationSynthesis.name,
+                                    overflow: TextOverflow.fade,
+                                    maxLines: 1,
+                                    style: classificationSynthesis.teamCode ==
+                                            widget.team.code
+                                        ? Theme.of(context).textTheme.bodyText2
+                                        : Theme.of(context).textTheme.bodyText1,
+                                  ),
+                                ),
+                                Expanded(
+                                    flex: 1,
+                                    child: Text(
+                                      "${classificationSynthesis.wonSets} pts",
+                                      style: classificationSynthesis.teamCode ==
+                                              widget.team.code
+                                          ? Theme.of(context)
+                                              .textTheme
+                                              .bodyText2
+                                          : Theme.of(context)
+                                              .textTheme
+                                              .bodyText1,
+                                    ))
+                              ],
+                            )),
+                      );
+                    }).toList()
                   ],
-                )),
-          );
-        }).toList()
+                )
+              : null,
+        ),
       ],
     );
   }
@@ -225,5 +270,21 @@ class _TeamRankingState extends State<TeamRanking> {
         ),
       ],
     );
+  }
+}
+
+class ClassificationClip extends CustomClipper<Rect> {
+  final double height;
+
+  ClassificationClip(this.height);
+
+  @override
+  Rect getClip(Size size) {
+    return Offset.zero & Size(size.width, height);
+  }
+
+  @override
+  bool shouldReclip(CustomClipper<Rect> oldClipper) {
+    return true;
   }
 }

--- a/lib/pages/team-details/ranking/team_ranking.dart
+++ b/lib/pages/team-details/ranking/team_ranking.dart
@@ -113,22 +113,25 @@ class TeamRanking extends StatelessWidget {
     return Column(
       children: <Widget>[
         StatisticsWidget(
-            title: "Matchs\ngagnés",
-            wonPoints: teamStats.wonMatches,
-            lostPoints: teamStats.lostMatches),
+          title: "Matchs\ngagnés",
+          wonPoints: teamStats.wonMatches,
+          maxPoints: teamStats.wonMatches + teamStats.lostMatches,
+        ),
         SummaryWidget(title: "Scores", teamStats: teamStats),
         StatisticsWidget(
-            title: "Sets pris",
-            wonPoints: teamStats.wonSets,
-            lostPoints: teamStats.lostSets),
+          title: "Sets pris",
+          wonPoints: teamStats.wonSets,
+          maxPoints: teamStats.wonSets + teamStats.lostSets,
+        ),
         EvolutionWidget(title: "Diff.\nde sets", evolution: setsDiffEvolution),
         EvolutionWidget(
             title: "Cumul diff.\nde sets",
             evolution: cumulativeSetsDiffEvolution),
         StatisticsWidget(
-            title: "Points pris",
-            wonPoints: teamStats.wonPoints,
-            lostPoints: teamStats.lostPoints),
+          title: "Points pris",
+          wonPoints: teamStats.wonPoints,
+          maxPoints: teamStats.wonPoints + teamStats.lostPoints,
+        ),
       ],
     );
   }

--- a/lib/pages/team-details/ranking/team_ranking.dart
+++ b/lib/pages/team-details/ranking/team_ranking.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:v34/commons/competition_badge.dart';
+import 'package:v34/commons/paragraph.dart';
 import 'package:v34/commons/podium_widget.dart';
 import 'package:v34/models/classication.dart';
 import 'package:v34/models/match_result.dart';
@@ -17,79 +18,120 @@ class TeamRanking extends StatelessWidget {
   final ClassificationSynthesis classification;
   final List<MatchResult> results;
 
-  const TeamRanking({Key key, @required this.team, @required this.classification, @required this.results}) : super(key: key);
+  const TeamRanking(
+      {Key key,
+      @required this.team,
+      @required this.classification,
+      @required this.results})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    int teamIndex = classification.teamsClassifications.indexWhere((element) => element.teamCode == team.code);
-    ClassificationTeamSynthesis stats = classification.teamsClassifications[teamIndex];
-    return SliverList(delegate: SliverChildListDelegate([
-      _buildTitle(context),
+    int teamIndex = classification.teamsClassifications
+        .indexWhere((element) => element.teamCode == team.code);
+    ClassificationTeamSynthesis stats =
+        classification.teamsClassifications[teamIndex];
+    return SliverList(
+        delegate: SliverChildListDelegate([
+      _buildCompetitionDescription(context),
+      Paragraph(title: "Classement"),
       _buildPodium(stats),
-      InformationDivider(title: "Statistiques", size: 15),
+      Paragraph(title: "Statistiques"),
       _buildStats(context, stats),
     ]));
   }
 
+  Widget _buildCompetitionDescription(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 48, bottom: 8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          Text(_getClassificationCategory(),
+              style: Theme.of(context).textTheme.headline4),
+          CompetitionBadge(
+              competitionCode: classification.competitionCode, deltaSize: 0.8),
+        ],
+      ),
+    );
+  }
+
   String _getClassificationCategory() {
     switch (classification.division) {
-      case "EX": return "- Excellence";
-      case "HO": return "- Honneur";
-      case "PR": return "- Promotion";
-      case "AC": return "- Accession";
-      case "L1": return "- Loisirs 1";
-      default: return _getPool();
+      case "EX":
+        return "Excellence";
+      case "HO":
+        return "Honneur";
+      case "PR":
+        return "Promotion";
+      case "AC":
+        return "Accession";
+      case "L1":
+        return "Loisirs 1";
+      default:
+        return _getPool();
     }
   }
 
   String _getPool() {
-    if (classification.pool == "0") return "";
-    else return "- Poule ${classification.pool}";
-  }
-
-  Widget _buildTitle(BuildContext context) {
-    return Stack(
-      children: <Widget>[
-        InformationDivider(title: "Classement ${_getClassificationCategory()}", size: 15),
-        Positioned(
-          top: 12,
-          right: 12,
-          child: CompetitionBadge(competitionCode: classification.competitionCode, deltaSize: 0.8)
-        )
-      ],
-    );
+    if (classification.pool == "0")
+      return "";
+    else
+      return "Poule ${classification.pool}";
   }
 
   Widget _buildPodium(ClassificationTeamSynthesis teamStats) {
     String title = "";
-    if (teamStats.rank <= classification.promoted) title = "Promue";
-    else if (classification.teamsClassifications.length - teamStats.rank < classification.relegated) title = "Reléguée";
+    if (teamStats.rank <= classification.promoted)
+      title = "Promue";
+    else if (classification.teamsClassifications.length - teamStats.rank <
+        classification.relegated) title = "Reléguée";
     return FractionallySizedBox(
       widthFactor: 0.7,
       child: Container(
         height: 150,
         child: Row(
           children: <Widget>[
-            Expanded(child: PodiumWidget(title: title, classification: classification, currentlyDisplayed: true, highlightedTeamCode: team.code)),
+            Expanded(
+                child: PodiumWidget(
+                    title: title,
+                    classification: classification,
+                    currentlyDisplayed: true,
+                    highlightedTeamCode: team.code)),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildStats(BuildContext context, ClassificationTeamSynthesis teamStats) {
-    List<double> setsDiffEvolution = TeamBloc.computePointsDiffs(results, team.code);
-    List<double> cumulativeSetsDiffEvolution = TeamBloc.computeCumulativePointsDiffs(setsDiffEvolution);
+  Widget _buildStats(
+      BuildContext context, ClassificationTeamSynthesis teamStats) {
+    List<double> setsDiffEvolution =
+        TeamBloc.computePointsDiffs(results, team.code);
+    List<double> cumulativeSetsDiffEvolution =
+        TeamBloc.computeCumulativePointsDiffs(setsDiffEvolution);
     return Column(
       children: <Widget>[
-        StatisticsWidget(title: "Matchs gagnés", wonPoints: teamStats.wonMatches, lostPoints: teamStats.lostMatches),
+        StatisticsWidget(
+            title: "Matchs gagnés",
+            wonPoints: teamStats.wonMatches,
+            lostPoints: teamStats.lostMatches),
         SummaryWidget(title: "Scores", teamStats: teamStats),
-        StatisticsWidget(title: "Set pris", wonPoints: teamStats.wonSets, lostPoints: teamStats.lostSets),
-        EvolutionWidget(title: "Ev. de la différence de sets", evolution: setsDiffEvolution),
-        EvolutionWidget(title: "Ev. de la différence de sets cumulée", evolution: cumulativeSetsDiffEvolution),
-        StatisticsWidget(title: "Points pris", wonPoints: teamStats.wonPoints, lostPoints: teamStats.lostPoints),
+        StatisticsWidget(
+            title: "Set pris",
+            wonPoints: teamStats.wonSets,
+            lostPoints: teamStats.lostSets),
+        EvolutionWidget(
+            title: "Ev. de la différence de sets",
+            evolution: setsDiffEvolution),
+        EvolutionWidget(
+            title: "Ev. de la différence de sets cumulée",
+            evolution: cumulativeSetsDiffEvolution),
+        StatisticsWidget(
+            title: "Points pris",
+            wonPoints: teamStats.wonPoints,
+            lostPoints: teamStats.lostPoints),
       ],
     );
   }
-
 }

--- a/lib/pages/team-details/ranking/team_ranking.dart
+++ b/lib/pages/team-details/ranking/team_ranking.dart
@@ -113,19 +113,17 @@ class TeamRanking extends StatelessWidget {
     return Column(
       children: <Widget>[
         StatisticsWidget(
-            title: "Matchs gagnés",
+            title: "Matchs\ngagnés",
             wonPoints: teamStats.wonMatches,
             lostPoints: teamStats.lostMatches),
         SummaryWidget(title: "Scores", teamStats: teamStats),
         StatisticsWidget(
-            title: "Set pris",
+            title: "Sets pris",
             wonPoints: teamStats.wonSets,
             lostPoints: teamStats.lostSets),
+        EvolutionWidget(title: "Diff.\nde sets", evolution: setsDiffEvolution),
         EvolutionWidget(
-            title: "Ev. de la différence de sets",
-            evolution: setsDiffEvolution),
-        EvolutionWidget(
-            title: "Ev. de la différence de sets cumulée",
+            title: "Cumul diff.\nde sets",
             evolution: cumulativeSetsDiffEvolution),
         StatisticsWidget(
             title: "Points pris",


### PR DESCRIPTION
Improve + Fixes:
  - Use Paragraph widget everywhere (with delimiter cc @thomasFoulon even in dashboard). 
  - Fix some typos in labels
  - Use shorter labels
  - Separate the competition label + badge from the paragraph
  - Add a label under the competition badge to explain what it stands for
  - Add a cup (Gold, Silver and Bronze) when needed
  - Add the whole list of teams classifications with their own points
  - Apply design guidelines (score distributions labels should use `bodytext1` style)