### PR TITLE
Fixes reload when deselect a team from favorites on its page

### DIFF
--- a/lib/pages/dashboard/widgets/team_card.dart
+++ b/lib/pages/dashboard/widgets/team_card.dart
@@ -91,7 +91,7 @@ class _TeamCardState extends State<TeamCard> {
           builder: (_) => TeamDetailPage(
               team: widget.team,
               classifications: state.classifications,
-              club: widget.club)).then((_) => widget.onFavoriteChange);
+              club: widget.club)).then((_) => widget.onFavoriteChange());
     } else
       return null;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "7.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.16"
+    version: "0.39.17"
   args:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -358,7 +358,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.4.0"
   like_button:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Teams on the dashboard (and therefore the agenda) weren't reloaded when a team was deselected of favourites directly on the team page.