### PR TITLE
Set a 'theme' (based on our theme) instead of default settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ lib/generated_plugin_registrant.dart
 # Exceptions to above rules.
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 /android/key.properties
+/ios/Flutter/.last_build_id

--- a/ios/Flutter/.last_build_id
+++ b/ios/Flutter/.last_build_id
@@ -1,1 +1,0 @@
-39c55ec2ecc7bfbc14bb98e41931e556

--- a/lib/pages/club/club_page.dart
+++ b/lib/pages/club/club_page.dart
@@ -14,8 +14,7 @@ class ClubPage extends StatefulWidget {
   _ClubPageState createState() => _ClubPageState();
 }
 
-class _ClubPageState extends State<ClubPage>
-    with SingleTickerProviderStateMixin {
+class _ClubPageState extends State<ClubPage> with SingleTickerProviderStateMixin {
   Repository _repository;
 
   List<Club> _clubs;
@@ -43,13 +42,9 @@ class _ClubPageState extends State<ClubPage>
         setState(() {
           _loading = false;
           clubs.sort((c1, c2) {
-            if (favorites.contains(c1.code) && !favorites.contains(c2.code))
-              return -1;
-            if (!favorites.contains(c1.code) && favorites.contains(c2.code))
-              return 1;
-            return c1.shortName
-                .toUpperCase()
-                .compareTo(c2.shortName.toUpperCase());
+            if (favorites.contains(c1.code) && !favorites.contains(c2.code)) return -1;
+            if (!favorites.contains(c1.code) && favorites.contains(c2.code)) return 1;
+            return c1.shortName.toUpperCase().compareTo(c2.shortName.toUpperCase());
           });
           _clubs = clubs;
         });
@@ -59,6 +54,7 @@ class _ClubPageState extends State<ClubPage>
 
   @override
   Widget build(BuildContext context) {
+    ThemeData currentTheme = Theme.of(context);
     return MainPage(
       title: "Clubs",
       actions: [
@@ -79,6 +75,14 @@ class _ClubPageState extends State<ClubPage>
                 club.code,
               ],
               builder: (club) => ClubCard(club, 1),
+              barTheme: Theme.of(context).copyWith(
+                textTheme: TextTheme(
+                  headline6: Theme.of(context).textTheme.headline4
+                ),
+                inputDecorationTheme: InputDecorationTheme(
+                  hintStyle: Theme.of(context).textTheme.headline5
+                ),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Now the search bar use a lighter and smaller font size. This style depends on values set in our themes, so any change will also change the search bar style and this is expected

Close #124 

![Simulator Screen Shot - iPhone 11 - 2020-08-25 at 01 26 44](https://user-images.githubusercontent.com/42940156/91106064-0e5f2c80-e672-11ea-9118-ea9b68160aa0.png)
