### PR TITLE
Set ITSAppUsesNonExemptEncryption to false

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -58,5 +58,7 @@
         <string>osmandmaps</string>
         <string>dgis</string>
     </array>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
Today even if a build is available on Apple Store Connect and even if we set this build to be available to iOS beta testers with TestFlight, users do not see the `Update` button on TestFlight and are unable to run the new build !

I have seen on StackOverflow that some developers were hitting the same issue and set this flag which solve the issue. BTW, Apple Store Connect does not show any warn or error...

So give it a try to this solution